### PR TITLE
TRIB 61.1: changes getReviewPhrase() name to testGetReviewPhraseHappyPath()

### DIFF
--- a/src/test/java/com/savvato/tribeapp/services/ToBeReviewedServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ToBeReviewedServiceImplTest.java
@@ -36,7 +36,7 @@ public class ToBeReviewedServiceImplTest extends AbstractServiceImplTest {
 
     // test that the method is returning the database's results correctly
     @Test
-    public void getReviewPhrase() {
+    public void testGetReviewPhraseHappyPath() {
         ToBeReviewed expectedToBeReviewed = new ToBeReviewed();
         expectedToBeReviewed.setId(1L);
         expectedToBeReviewed.setHasBeenGroomed(true);


### PR DESCRIPTION
Jonathan requested this change via Slack as we discussed TRIB-61 in an attempt to consistently use the naming convention of "testTestName()" for all unit tests.