### PR TITLE
mrsbluerose phrase fix: updated phrase entity to use ids 

### DIFF
--- a/src/main/java/com/savvato/tribeapp/entities/Phrase.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Phrase.java
@@ -12,51 +12,52 @@ public class Phrase {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    public String adverb;
+    public int adverbId;
 
-    public String verb;
+    public int verbId;
 
-    public String preposition;
+    public int prepositionId;
 
-    public String noun;
-
+    public int nounID;
 
     public Long getId() {
         return id;
     }
 
-    public void setId(Long id) {this.id = id;}
-
-    public String getAdverb() {
-        return adverb;
+    public void setId(Long id) {
+        this.id = id;
     }
 
-    public void setAdverb(String adverb) {
-        this.adverb = adverb;
+    public int getAdverbId() {
+        return adverbId;
     }
 
-    public String getVerb() {
-        return verb;
+    public void setAdverbId(int adverbId) {
+        this.adverbId = adverbId;
     }
 
-    public void setVerb(String verb) {
-        this.verb = verb;
+    public int getVerbId() {
+        return verbId;
     }
 
-    public String getPreposition() {
-        return preposition;
+    public void setVerbId(int verbId) {
+        this.verbId = verbId;
     }
 
-    public void setPreposition(String preposition) {
-        this.preposition = preposition;
+    public int getPrepositionId() {
+        return prepositionId;
     }
 
-    public String getNoun() {
-        return noun;
+    public void setPrepositionId(int prepositionId) {
+        this.prepositionId = prepositionId;
     }
 
-    public void setNoun(String noun) {
-        this.noun = noun;
+    public int getNounID() {
+        return nounID;
+    }
+
+    public void setNounID(int nounID) {
+        this.nounID = nounID;
     }
 }
 


### PR DESCRIPTION
In our previous meeting, I submitted a pull request for the phrase entity I created. The word properties were strings. In the database table, they are listed as the word ids.