### PR TITLE
Trib 72: bug fix. Updates get attributes return type to Optional of array list

### DIFF
--- a/src/main/java/com/savvato/tribeapp/services/AttributesServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/AttributesServiceImpl.java
@@ -105,7 +105,7 @@ public class AttributesServiceImpl implements AttributesService{
             }
         }
 
-        // Return Optional of attributes or empty Optional if there aren't any
-        return (attributes.isEmpty() ? Optional.empty() : Optional.of(attributes));
+        // Returns list of attributeDTOs. Can be empty.
+        return Optional.of(attributes);
     }
 }


### PR DESCRIPTION
/api/attributes/{userId} endpoint now returns an optional of the array list of attributeDTOs. It is able to return an empty list, which results in a 200 HTTP response status code when there aren't any attributes for the user.