### PR TITLE
Trib 95: updates phrase service methods and calls to grammatical order

### DIFF
--- a/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
@@ -45,7 +45,7 @@ public class AttributesAPIController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
 
         if (phraseService.isPhraseValid(req.adverb, req.verb, req.preposition, req.noun)) {
-            phraseService.applyPhraseToUser(req.noun, req.verb, req.preposition, req.adverb);
+            phraseService.applyPhraseToUser(req.adverb, req.verb, req.preposition, req.noun);
         }
 
         if (rtn)

--- a/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
@@ -44,7 +44,7 @@ public class AttributesAPIController {
         if (req.noun == null || req.verb == null)
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
 
-        if (phraseService.isPhraseValid(req.noun, req.verb, req.preposition, req.adverb)) {
+        if (phraseService.isPhraseValid(req.adverb, req.verb, req.preposition, req.noun)) {
             phraseService.applyPhraseToUser(req.noun, req.verb, req.preposition, req.adverb);
         }
 

--- a/src/main/java/com/savvato/tribeapp/services/PhraseService.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseService.java
@@ -9,7 +9,7 @@ public interface PhraseService {
 
     boolean isPhraseValid(String adverb, String verb, String preposition, String noun);
 
-    void applyPhraseToUser(String verb, String noun, String adverb, String preposition);
+    void applyPhraseToUser(String adverb, String verb, String preposition, String noun);
 
     Optional<List<PhraseDTO>> getListOfPhraseDTOByUserId(Long id);
 }

--- a/src/main/java/com/savvato/tribeapp/services/PhraseService.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseService.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface PhraseService {
 
-    boolean isPhraseValid(String verb, String noun, String adverb, String preposition);
+    boolean isPhraseValid(String adverb, String verb, String preposition, String noun);
 
     void applyPhraseToUser(String verb, String noun, String adverb, String preposition);
 

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -49,7 +49,7 @@ public class PhraseServiceImpl implements PhraseService {
     }
 
     public void applyPhraseToUser(String adverb, String verb, String preposition, String noun) {
-        boolean rtn = hasPhraseBeenReviewed(verb, noun, adverb, preposition);
+        boolean rtn = hasPhraseBeenReviewed(adverb, verb, preposition, noun);
 
         if (rtn) {
             // we have seen this before
@@ -61,12 +61,12 @@ public class PhraseServiceImpl implements PhraseService {
         }
     }
 
-    public boolean hasPhraseBeenReviewed(String verb, String noun, String adverb, String preposition) {
+    public boolean hasPhraseBeenReviewed(String adverb, String verb, String preposition, String noun) {
         boolean rtn = true;
-        rtn = rtn && isGivenVerbFound(verb);
-        rtn = rtn && isGivenNounFound(noun);
-        rtn = rtn && isGivenAdverbFound(adverb);
-        rtn = rtn && isGivenPrepositionFound(preposition);
+        rtn = rtn && isGivenVerbFound(adverb);
+        rtn = rtn && isGivenNounFound(verb);
+        rtn = rtn && isGivenAdverbFound(preposition);
+        rtn = rtn && isGivenPrepositionFound(noun);
 
         return rtn;
     }

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -23,13 +23,13 @@ public class PhraseServiceImpl implements PhraseService {
     AdverbRepository adverbRepository;
 
     @Autowired
-    NounRepository nounRepository;
+    VerbRepository verbRepository;
 
     @Autowired
     PrepositionRepository prepositionRepository;
 
     @Autowired
-    VerbRepository verbRepository;
+    NounRepository nounRepository;
 
     @Autowired
     RejectedNonEnglishWordRepository rejectedNonEnglishWordRepository;
@@ -71,22 +71,22 @@ public class PhraseServiceImpl implements PhraseService {
         return rtn;
     }
 
-    public boolean isGivenVerbFound(String verb) {
-        return this.verbRepository.findByWord(verb).isPresent();
-    }
-
-    public boolean isGivenNounFound(String noun) {
-        return this.nounRepository.findByWord(noun).isPresent();
-    }
-
     public boolean isGivenAdverbFound(String adverb) {
         return this.adverbRepository.findByWord(adverb).isPresent();
+    }
+
+    public boolean isGivenVerbFound(String verb) {
+        return this.verbRepository.findByWord(verb).isPresent();
     }
 
     public boolean isGivenPrepositionFound(String preposition) {
         return this.prepositionRepository.findByWord(preposition).isPresent();
     }
 
+    public boolean isGivenNounFound(String noun) {
+        return this.nounRepository.findByWord(noun).isPresent();
+    }
+    
     @Override
     public Optional<List<PhraseDTO>> getListOfPhraseDTOByUserId(Long userId) {
 

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -34,12 +34,12 @@ public class PhraseServiceImpl implements PhraseService {
     @Autowired
     RejectedNonEnglishWordRepository rejectedNonEnglishWordRepository;
 
-    public boolean isPhraseValid(String verb, String noun, String adverb, String preposition) {
+    public boolean isPhraseValid(String adverb, String verb, String preposition, String noun) {
         boolean rtn = true;
-        rtn = rtn && isWordPreviouslyRejected(verb);
-        rtn = rtn && isWordPreviouslyRejected(noun);
         rtn = rtn && isWordPreviouslyRejected(adverb);
+        rtn = rtn && isWordPreviouslyRejected(verb);
         rtn = rtn && isWordPreviouslyRejected(preposition);
+        rtn = rtn && isWordPreviouslyRejected(noun);
 
         return rtn;
     }

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -48,7 +48,7 @@ public class PhraseServiceImpl implements PhraseService {
         return this.rejectedNonEnglishWordRepository.findByWord(word).isPresent();
     }
 
-    public void applyPhraseToUser(String verb, String noun, String adverb, String preposition) {
+    public void applyPhraseToUser(String adverb, String verb, String preposition, String noun) {
         boolean rtn = hasPhraseBeenReviewed(verb, noun, adverb, preposition);
 
         if (rtn) {


### PR DESCRIPTION
Goal: create consistency early on by keeping phrase words in grammatical order
Grammatical order defined: adverb, verb, preposition, noun
Changes made:
- Updates PhraseService and Interface method signatures and properties to grammatical order
- Updates all current calls to these methods in AttributesAPIController to match