### PR TITLE
TRIB-113: updates database rejected_phrase table column name

### DIFF
--- a/src/main/resources/db/migration/changelog-202304141047.xml
+++ b/src/main/resources/db/migration/changelog-202304141047.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <!-- sets auto-increment for word database columns -->
+    <changeSet author="audra" id="202304141047-01">
+        <sql dbms="mysql">
+
+            ALTER TABLE adverb AUTO_INCREMENT=100;
+            ALTER TABLE verb AUTO_INCREMENT=100;
+            ALTER TABLE preposition AUTO_INCREMENT=100;
+            ALTER TABLE noun AUTO_INCREMENT=100;
+
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-202304141049.xml
+++ b/src/main/resources/db/migration/changelog-202304141049.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <!-- Alters phrase table to accept null values so that words can be removed for following scripts -->
+    <changeSet author="audra" id="202304141049-01">
+        <sql dbms="mysql">
+            ALTER TABLE phrase MODIFY adverb_id BIGINT(20);
+            ALTER TABLE phrase MODIFY verb_id BIGINT(20);
+            ALTER TABLE phrase MODIFY preposition_id BIGINT(20);
+            ALTER TABLE phrase MODIFY noun_id BIGINT(20);
+        </sql>
+    </changeSet>
+
+    <!-- Removes words from test data phrases temporarily for following scripts to alter ids -->
+    <changeSet author="audra" id="202304141049-02" context="test">
+        <sql dbms="mysql">
+            UPDATE phrase SET adverb_id = null, verb_id = null, noun_id = null WHERE id = 1;
+            UPDATE phrase SET verb_id = null, noun_id = null WHERE id = 2;
+            UPDATE phrase SET verb_id = null, preposition_id = null, noun_id = null WHERE id = 3;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-202304141125.xml
+++ b/src/main/resources/db/migration/changelog-202304141125.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <!-- Changes existing words in test data to match new auto-increment numbering starting point of 100 -->
+    <changeSet author="audra" id="202304141125-01" context="test">
+        <sql dbms="mysql">
+            UPDATE adverb SET id = 100 WHERE word = 'competitively';
+
+            UPDATE verb SET id = 100 WHERE word = 'writes';
+            UPDATE verb SET id = 101 WHERE word = 'plays';
+            UPDATE verb SET id = 102 WHERE word = 'sculpts';
+
+            UPDATE preposition SET id = 100 WHERE word = 'with';
+
+            UPDATE noun SET id = 100 WHERE word = 'code';
+            UPDATE noun SET id = 101 WHERE word = 'chess';
+            UPDATE noun SET id = 102 WHERE word = 'clay';
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-202304141136.xml
+++ b/src/main/resources/db/migration/changelog-202304141136.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <!-- inserts word "nullvalue" into adverb and preposition tables to be used when no word in phrase -->
+    <changeSet author="audra" id="202304141136-01" >
+        <sql dbms="mysql">
+            INSERT INTO adverb (word) VALUES ('nullvalue');
+            INSERT INTO preposition (word) VALUES ('nullvalue');
+        </sql>
+    </changeSet>
+
+    <!-- sets "nullvalue" id to "1" in adverb and preposition tables -->
+    <changeSet author="audra" id="202304141136-02" >
+        <sql dbms="mysql">
+            UPDATE adverb SET id = 1 WHERE word = 'nullvalue';
+            UPDATE preposition SET id = 1 WHERE word = 'nullvalue';
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-202304141143.xml
+++ b/src/main/resources/db/migration/changelog-202304141143.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <!--
+    inserts test data words back into phrases with new auto-increment numbering
+    prases without adverb or preposition use id "1" for "nullvalue"
+    -->
+    <changeSet author="audra" id="202304141143-01" context="test">
+        <sql dbms="mysql">
+            UPDATE phrase SET adverb_id = 100, verb_id = 100, preposition_id = 1, noun_id = 100 WHERE id = 1;
+            UPDATE phrase SET adverb_id = 1, verb_id = 101, preposition_id = 1, noun_id = 101 WHERE id = 2;
+            UPDATE phrase SET adverb_id = 1, verb_id = 102, preposition_id = 100, noun_id = 102 WHERE id = 3;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-202304141226.xml
+++ b/src/main/resources/db/migration/changelog-202304141226.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <!-- Alters phrase table to NOT accept null values -->
+    <changeSet author="audra" id="202304141226-01">
+        <sql dbms="mysql">
+            ALTER TABLE phrase MODIFY adverb_id BIGINT(20) NOT NULL;
+            ALTER TABLE phrase MODIFY verb_id BIGINT(20) NOT NULL;
+            ALTER TABLE phrase MODIFY preposition_id BIGINT(20) NOT NULL;
+            ALTER TABLE phrase MODIFY noun_id BIGINT(20) NOT NULL;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-202304211617.xml
+++ b/src/main/resources/db/migration/changelog-202304211617.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <!-- Alters phrase table to NOT accept null values -->
+    <changeSet author="audra" id="202304211617-01">
+        <sql dbms="mysql">
+            ALTER TABLE rejected_phrase RENAME COLUMN `rejected-phrase` TO rejected_phrase;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-master.xml
+++ b/src/main/resources/db/migration/changelog-master.xml
@@ -26,6 +26,7 @@
 	<include file="changelog-202304141136.xml" 	relativeToChangelogFile="true"/>
 	<include file="changelog-202304141143.xml" 	relativeToChangelogFile="true"/>
 	<include file="changelog-202304141226.xml" 	relativeToChangelogFile="true"/>
+	<include file="changelog-202304211617.xml" 	relativeToChangelogFile="true"/>
 
 </databaseChangeLog>
 

--- a/src/main/resources/db/migration/changelog-master.xml
+++ b/src/main/resources/db/migration/changelog-master.xml
@@ -19,6 +19,12 @@
 	<include file="changelog-202303281903.xml" 	relativeToChangelogFile="true"/>
 	<include file="changelog-202304021000.xml" 	relativeToChangelogFile="true"/>
 	<include file="changelog-202304021328.xml" 	relativeToChangelogFile="true"/>
+	<include file="changelog-202304141047.xml" 	relativeToChangelogFile="true"/>
+	<include file="changelog-202304141049.xml" 	relativeToChangelogFile="true"/>
+	<include file="changelog-202304141125.xml" 	relativeToChangelogFile="true"/>
+	<include file="changelog-202304141136.xml" 	relativeToChangelogFile="true"/>
+	<include file="changelog-202304141143.xml" 	relativeToChangelogFile="true"/>
+	<include file="changelog-202304141226.xml" 	relativeToChangelogFile="true"/>
 
 </databaseChangeLog>
 


### PR DESCRIPTION
This migration script updates the column rejected-phrase to rejected_phrase. The previous name was creating access problems in the repo, but this updated name functions as expected. Was able to test adding records in MySQL workbench.