### PR TITLE
Trib 74: apply phrase to user when has not been approved

### DIFF
--- a/src/main/java/com/savvato/tribeapp/entities/ReviewSubmittingUserId.java
+++ b/src/main/java/com/savvato/tribeapp/entities/ReviewSubmittingUserId.java
@@ -10,4 +10,7 @@ public class ReviewSubmittingUserId implements Serializable {
         this.userId = userId;
         this.toBeReviewedId = toBeReviewedId;
     }
+
+    public ReviewSubmittingUserId() {
+    }
 }

--- a/src/main/java/com/savvato/tribeapp/repositories/ReviewSubmittingUserRepository.java
+++ b/src/main/java/com/savvato/tribeapp/repositories/ReviewSubmittingUserRepository.java
@@ -1,6 +1,7 @@
 package com.savvato.tribeapp.repositories;
 
 import com.savvato.tribeapp.entities.ReviewSubmittingUser;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
@@ -9,4 +10,8 @@ import org.springframework.stereotype.Repository;
 public interface ReviewSubmittingUserRepository extends CrudRepository<ReviewSubmittingUser, Long> {
     @Query(nativeQuery = true, value="delete from review_submitting_user rsu where rsu.toBeReviewedId=?1")
     Long deleteByToBeReviewedId(Long toBeReviewedId);
+
+    @Modifying
+    @Query(nativeQuery = true, value="INSERT INTO review_submitting_user (userId, toBeReviewedId) VALUES (?,?)")
+    Long saveUserAndReview(Long userId, Long toBeReviewedId);
 }

--- a/src/main/java/com/savvato/tribeapp/repositories/ReviewSubmittingUserRepository.java
+++ b/src/main/java/com/savvato/tribeapp/repositories/ReviewSubmittingUserRepository.java
@@ -10,8 +10,5 @@ import org.springframework.stereotype.Repository;
 public interface ReviewSubmittingUserRepository extends CrudRepository<ReviewSubmittingUser, Long> {
     @Query(nativeQuery = true, value="delete from review_submitting_user rsu where rsu.to_be_reviewed_id=?1")
     Long deleteByToBeReviewedId(Long toBeReviewedId);
-
-    @Modifying
-    @Query(nativeQuery = true, value="INSERT INTO review_submitting_user (userId, toBeReviewedId) VALUES (?,?)")
-    Long saveUserAndReview(Long userId, Long toBeReviewedId);
+    
 }

--- a/src/main/java/com/savvato/tribeapp/repositories/ReviewSubmittingUserRepository.java
+++ b/src/main/java/com/savvato/tribeapp/repositories/ReviewSubmittingUserRepository.java
@@ -1,7 +1,6 @@
 package com.savvato.tribeapp.repositories;
 
 import com.savvato.tribeapp.entities.ReviewSubmittingUser;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/savvato/tribeapp/repositories/ToBeReviewedRepository.java
+++ b/src/main/java/com/savvato/tribeapp/repositories/ToBeReviewedRepository.java
@@ -16,4 +16,6 @@ public interface ToBeReviewedRepository extends CrudRepository<ToBeReviewed, Lon
     List<ToBeReviewed> getAllUngroomed();
     void deleteById(Long id);
 
+    Optional<ToBeReviewed> findByAdverbAndVerbAndNounAndPreposition(String adverb, String verb, String noun, String preposition);
+
 }

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -239,11 +239,10 @@ public class PhraseServiceImpl implements PhraseService {
     }
 
     public void addUserAndPhraseToReviewSubmittingUserRepository(Long userId, Long toBeReviewedId) {
-        ReviewSubmittingUser reviewSubmittingUser = new ReviewSubmittingUser(userId, toBeReviewedId);
-//        reviewSubmittingUser.setUserId(userId);
-//        reviewSubmittingUser.setToBeReviewedId(toBeReviewedId);
-        //reviewSubmittingUserRepository.save(reviewSubmittingUser);
-        reviewSubmittingUserRepository.saveUserAndReview(userId, toBeReviewedId);
+        ReviewSubmittingUser reviewSubmittingUser = new ReviewSubmittingUser();
+        reviewSubmittingUser.setToBeReviewedId(userId);
+        reviewSubmittingUser.setToBeReviewedId(toBeReviewedId);
+        reviewSubmittingUserRepository.save(reviewSubmittingUser);
     }
 
     @Override

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -143,7 +143,7 @@ public class PhraseServiceImpl implements PhraseService {
             userPhraseRepository.save(userPhrase);
             logger.info("Phrase added to user.");
         } else {
-            Optional<ToBeReviewed> toBeReviewedPhrase = toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(adverb, verb, noun, preposition);
+            Optional<ToBeReviewed> toBeReviewedPhrase = toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(adverbLowerCase, verbLowerCase, nounLowerCase, prepositionLowerCase);
 
             if (toBeReviewedPhrase.isPresent()) {
                 addUserAndPhraseToReviewSubmittingUserRepository(userId, toBeReviewedPhrase.get().getId());
@@ -151,14 +151,14 @@ public class PhraseServiceImpl implements PhraseService {
             } else {
                 ToBeReviewed toBeReviewed = new ToBeReviewed();
                 toBeReviewed.setHasBeenGroomed(false);
-                toBeReviewed.setAdverb(adverb);
-                toBeReviewed.setVerb(verb);
-                toBeReviewed.setPreposition(preposition);
-                toBeReviewed.setNoun(noun);
+                toBeReviewed.setAdverb(adverbLowerCase);
+                toBeReviewed.setVerb(verbLowerCase);
+                toBeReviewed.setPreposition(prepositionLowerCase);
+                toBeReviewed.setNoun(nounLowerCase);
                 toBeReviewedRepository.save(toBeReviewed);
                 logger.info("phrase added to to_be_reviewed table");
 
-                Optional<ToBeReviewed> toBeReviewedPhraseNew = toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(adverb, verb, noun, preposition);
+                Optional<ToBeReviewed> toBeReviewedPhraseNew = toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(adverbLowerCase, verbLowerCase, nounLowerCase, prepositionLowerCase);
 
                 addUserAndPhraseToReviewSubmittingUserRepository(userId, toBeReviewedPhraseNew.get().getId());
                 logger.info("ToBeReviewed phrase has been mapped to user");

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -143,21 +143,12 @@ public class PhraseServiceImpl implements PhraseService {
             logger.info("Phrase added to user.");
 
         } else {
-            // we have not seen this before
-            // add it to the database
-            // associate it with the user
+            Optional<ToBeReviewed> toBeReviewedPhrase = toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(adverb, verb, noun, preposition);
 
-            // we have already checked if it is valid and if it was already approved
-            // check to_be_reviewed table for phrase and get ID
-            Optional<ToBeReviewed> toBeReviewedPhrase = toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(adverb, verb, noun, preposition); //test order
-            // if so, get phrase id
             if (toBeReviewedPhrase.isPresent()) {
                 addUserAndPhraseToReviewSubmittingUserRepository(userId, toBeReviewedPhrase.get().getId());
-                //logger.info("ToBeReviewed phrase has been mapped to user");
+                logger.info("ToBeReviewed phrase has been mapped to user");
             } else {
-                // if not, add phrase to to_be_reviewed table and get phrase id
-                // map user id and phrase id in review_submitting_user table
-
                 ToBeReviewed toBeReviewed = new ToBeReviewed();
                 toBeReviewed.setHasBeenGroomed(false);
                 toBeReviewed.setAdverb(adverb);
@@ -165,14 +156,14 @@ public class PhraseServiceImpl implements PhraseService {
                 toBeReviewed.setPreposition(preposition);
                 toBeReviewed.setNoun(noun);
                 toBeReviewedRepository.save(toBeReviewed);
-                //logger.info("phrase added to to_be_reviewed table")
+                logger.info("phrase added to to_be_reviewed table");
 
-                // what kind of exceptions or errors should I be throwing if something goes wrong with saving to database, or retrieving something I know should be there?
-
-                Optional<ToBeReviewed> toBeReviewedPhraseNew = toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(adverb, verb, noun, preposition); //test order
+                Optional<ToBeReviewed> toBeReviewedPhraseNew = toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(adverb, verb, noun, preposition);
 
                 addUserAndPhraseToReviewSubmittingUserRepository(userId, toBeReviewedPhraseNew.get().getId());
-                //logger.info("ToBeReviewed phrase has been mapped to user");
+                logger.info("ToBeReviewed phrase has been mapped to user");
+
+                // what kind of exceptions or errors should I be throwing if something goes wrong with saving to database, or retrieving something I know should be there?
             }
         }
 
@@ -240,7 +231,7 @@ public class PhraseServiceImpl implements PhraseService {
 
     public void addUserAndPhraseToReviewSubmittingUserRepository(Long userId, Long toBeReviewedId) {
         ReviewSubmittingUser reviewSubmittingUser = new ReviewSubmittingUser();
-        reviewSubmittingUser.setToBeReviewedId(userId);
+        reviewSubmittingUser.setUserId(userId);
         reviewSubmittingUser.setToBeReviewedId(toBeReviewedId);
         reviewSubmittingUserRepository.save(reviewSubmittingUser);
     }

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -141,7 +141,6 @@ public class PhraseServiceImpl implements PhraseService {
             userPhrase.setPhraseId(previouslyReviewedPhraseId.get());
             userPhraseRepository.save(userPhrase);
             logger.info("Phrase added to user.");
-
         } else {
             Optional<ToBeReviewed> toBeReviewedPhrase = toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(adverb, verb, noun, preposition);
 
@@ -162,11 +161,8 @@ public class PhraseServiceImpl implements PhraseService {
 
                 addUserAndPhraseToReviewSubmittingUserRepository(userId, toBeReviewedPhraseNew.get().getId());
                 logger.info("ToBeReviewed phrase has been mapped to user");
-
-                // what kind of exceptions or errors should I be throwing if something goes wrong with saving to database, or retrieving something I know should be there?
             }
         }
-
     }
 
     @Override

--- a/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
@@ -139,5 +139,63 @@ public class PhraseServiceImplTest extends AbstractServiceImplTest {
 
     }
 
-    // Test that UserPhraseRepository is called once when calling ApplyPhraseToUser and phrase has not been approved
+    // Test that reviewSubmittingUserRepository is called once when calling ApplyPhraseToUser and conditions:
+    // phrase has not been approved
+    // phrase exists in to_be_reviewed
+    @Test
+    public void testApplyPhraseToUserWhenPhraseExistsInToBeReviewed() {
+        User user1 = getUser1();
+
+        String testWord = "test";
+        ToBeReviewed toBeReviewed = new ToBeReviewed();
+        toBeReviewed.setId(1L);
+        toBeReviewed.setHasBeenGroomed(false);
+        toBeReviewed.setAdverb(testWord);
+        toBeReviewed.setVerb(testWord);
+        toBeReviewed.setPreposition(testWord);
+        toBeReviewed.setNoun(testWord);
+
+        Mockito.when(adverbRepository.findByWord(anyString())).thenReturn(Optional.empty());
+        Mockito.when(verbRepository.findByWord(anyString())).thenReturn(Optional.empty());
+        Mockito.when(prepositionRepository.findByWord(anyString())).thenReturn(Optional.empty());
+        Mockito.when(nounRepository.findByWord(anyString())).thenReturn(Optional.empty());
+
+        Mockito.when(phraseRepository.findByAdverbIdAndVerbIdAndPrepositionIdAndNounId(any(Long.class), any(Long.class), any(Long.class), any(Long.class))).thenReturn(Optional.empty());
+
+        Mockito.when(toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(anyString(), anyString(), anyString(),anyString())).thenReturn(Optional.of(toBeReviewed));
+
+        phraseService.applyPhraseToUser(user1.getId(), testWord, testWord, testWord, testWord);
+
+        verify(reviewSubmittingUserRepository, times(1)).save(Mockito.any());
+    }
+
+    // Test that reviewSubmittingUserRepository is called once when calling ApplyPhraseToUser and conditions:
+    // phrase has not been approved
+    // phrase does not exist in to_be_reviewed
+    @Test
+    public void testApplyPhraseToUserWhenPhraseDoesNotExistInToBeReviewed() {
+        User user1 = getUser1();
+
+        String testWord = "test";
+        ToBeReviewed toBeReviewed = new ToBeReviewed();
+        toBeReviewed.setId(1L);
+        toBeReviewed.setHasBeenGroomed(false);
+        toBeReviewed.setAdverb(testWord);
+        toBeReviewed.setVerb(testWord);
+        toBeReviewed.setPreposition(testWord);
+        toBeReviewed.setNoun(testWord);
+
+        Mockito.when(adverbRepository.findByWord(anyString())).thenReturn(Optional.empty());
+        Mockito.when(verbRepository.findByWord(anyString())).thenReturn(Optional.empty());
+        Mockito.when(prepositionRepository.findByWord(anyString())).thenReturn(Optional.empty());
+        Mockito.when(nounRepository.findByWord(anyString())).thenReturn(Optional.empty());
+
+        Mockito.when(phraseRepository.findByAdverbIdAndVerbIdAndPrepositionIdAndNounId(any(Long.class), any(Long.class), any(Long.class), any(Long.class))).thenReturn(Optional.empty());
+
+        Mockito.when(toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(anyString(), anyString(), anyString(),anyString())).thenReturn(Optional.empty()).thenReturn(Optional.of(toBeReviewed));
+
+        phraseService.applyPhraseToUser(user1.getId(), testWord, testWord, testWord, testWord);
+
+        verify(reviewSubmittingUserRepository, times(1)).save(Mockito.any());
+    }
 }

--- a/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
@@ -107,7 +107,7 @@ public class PhraseServiceImplTest extends AbstractServiceImplTest {
         assertFalse(phraseService.isPhraseValid("test", "test", "test", "test"));
     }
 
-    // Test that UserPhraseRepository is called once when calling ApplyPhraseToUser
+    // Test that UserPhraseRepository is called once when calling ApplyPhraseToUser and phrase has been approved
     @Test
     public void testApplyPhraseToUserForOneCallToUserPhraseRepository() {
 
@@ -138,4 +138,6 @@ public class PhraseServiceImplTest extends AbstractServiceImplTest {
         verify(userPhraseRepository, times(1)).save(Mockito.any());
 
     }
+
+    // Test that UserPhraseRepository is called once when calling ApplyPhraseToUser and phrase has not been approved
 }

--- a/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
@@ -109,7 +109,7 @@ public class PhraseServiceImplTest extends AbstractServiceImplTest {
 
     // Test that UserPhraseRepository is called once when calling ApplyPhraseToUser and phrase has been approved
     @Test
-    public void testApplyPhraseToUserForOneCallToUserPhraseRepository() {
+    public void testApplyPhraseToUserWhenPhraseHasBeenPreviouslyApproved() {
 
         User user1 = getUser1();
 

--- a/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
@@ -60,6 +60,12 @@ public class PhraseServiceImplTest extends AbstractServiceImplTest {
     @MockBean
     UserPhraseRepository userPhraseRepository;
 
+    @MockBean
+    ToBeReviewedRepository toBeReviewedRepository;
+
+    @MockBean
+    ReviewSubmittingUserRepository reviewSubmittingUserRepository;
+
     // test that illegal argument is thrown when method is called with a null verb or noun
     @Test
     public void testIsMissingVerbOrNounHappyPath() {


### PR DESCRIPTION
When ApplyPhraseToUser is called with a phrase that has not been approved,
check if it is in the to_be_reviewed table
if so, map to user in review_submitting_user table
if not, add to to_be_reviewed table and then map to user

Testing:
- Tested in Postman & MySQL Workbench (passed)
- I can add a unit test, but I am waiting for my previous pull request to be approved (it adds test objects for phrase and words to the abstract test class). Please let me know if you want me to add that test here or open a separate ticket.