### PR TITLE
Trib 63: apply database foreign keys and correct column names

### DIFF
--- a/src/main/resources/db/migration/changelog-202305081206.xml
+++ b/src/main/resources/db/migration/changelog-202305081206.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="audra" id="202305081206-01">
+        <sql dbms="mysql">
+            ALTER TABLE review_decision RENAME COLUMN reviewId TO to_be_reviewed_id;
+            ALTER TABLE review_decision RENAME COLUMN userId TO user_id;
+            ALTER TABLE review_decision RENAME COLUMN reviewDecisionReasonId TO review_decision_reason_id;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-202305090846.xml
+++ b/src/main/resources/db/migration/changelog-202305090846.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="audra" id="202305090846-01">
+        <sql dbms="mysql">
+            ALTER TABLE user_user_role_map ADD PRIMARY KEY(user_id, user_role_id);
+            ALTER TABLE review_submitting_user ADD PRIMARY KEY(user_id, to_be_reviewed_id);
+            ALTER TABLE review_decision ADD PRIMARY KEY(user_id, to_be_reviewed_id);
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-202305090856.xml
+++ b/src/main/resources/db/migration/changelog-202305090856.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="audra" id="202305090856-01">
+        <sql dbms="mysql">
+            ALTER TABLE rejected_phrase MODIFY rejected_phrase VARCHAR(512) NOT NULL;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-master.xml
+++ b/src/main/resources/db/migration/changelog-master.xml
@@ -29,6 +29,7 @@
 	<include file="changelog-202304171308.xml" 	relativeToChangelogFile="true"/>
 	<include file="changelog-202304211617.xml" 	relativeToChangelogFile="true"/>
 	<include file="changelog-202304251612.xml" 	relativeToChangelogFile="true"/>
+	<include file="changelog-202305081206.xml" 	relativeToChangelogFile="true"/>
 
 </databaseChangeLog>
 

--- a/src/main/resources/db/migration/changelog-master.xml
+++ b/src/main/resources/db/migration/changelog-master.xml
@@ -30,6 +30,7 @@
 	<include file="changelog-202304211617.xml" 	relativeToChangelogFile="true"/>
 	<include file="changelog-202304251612.xml" 	relativeToChangelogFile="true"/>
 	<include file="changelog-202305081206.xml" 	relativeToChangelogFile="true"/>
+	<include file="changelog-202305090846.xml" 	relativeToChangelogFile="true"/>
 
 </databaseChangeLog>
 

--- a/src/main/resources/db/migration/changelog-master.xml
+++ b/src/main/resources/db/migration/changelog-master.xml
@@ -31,6 +31,7 @@
 	<include file="changelog-202304251612.xml" 	relativeToChangelogFile="true"/>
 	<include file="changelog-202305081206.xml" 	relativeToChangelogFile="true"/>
 	<include file="changelog-202305090846.xml" 	relativeToChangelogFile="true"/>
+	<include file="changelog-202305090856.xml" 	relativeToChangelogFile="true"/>
 
 </databaseChangeLog>
 


### PR DESCRIPTION
Changes:
- added migration script to changelog master to update review_decision column names to use underscores (no other changes to files. The ReviewDecisionRepository did not have any custom queries with the old field names)

Reviewed all database tables for primary and foreign keys. I did NOT make any changes to these tables (please let me know if any of these do need changed):
1. Did not touch DATABASECHANGELOG and DATABASECHANGELOGLOCK. I assume these are specifically formatted for a reason. DATABASECHANGELOG has an ID column and a DEPLOYMENT_ID column, but neither are specified as primary or foreign key.
2. review_decision has no primary key and three foreign keys (four columns total)
3. review_submitting_user has no primary key and the only two columns are foreign keys
4. user_phrase has a composite primary key of two columns which are also foreign keys
5. user_user_role_map has no primary key and the only two columns are foreign keys