### PR TITLE
Implemented websocket to handle connection-related communication between frontend and backend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,22 @@
 			<artifactId>ehcache</artifactId>
 			<version>3.4.0</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.springframework/spring-websocket -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-websocket</artifactId>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.springframework/spring-messaging -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-messaging</artifactId>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.springframework/spring-web -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+		</dependency>
+
 
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/savvato/tribeapp/config/ConnectWebSocketConfig.java
+++ b/src/main/java/com/savvato/tribeapp/config/ConnectWebSocketConfig.java
@@ -1,0 +1,26 @@
+package com.savvato.tribeapp.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class ConnectWebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        // broker will carry messages back to client based on link "/secured/user/queue/specific-user-userabcde123"
+        config.enableSimpleBroker("/connect/user/queue/specific-user");
+        // set prefix that prompts Spring to make a new queue specific to the user
+        config.setUserDestinationPrefix("/connect/user");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // the endpoint which frontend will subscribe to
+        registry.addEndpoint("/connect/room").withSockJS();
+    }
+}

--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -1,11 +1,17 @@
 package com.savvato.tribeapp.controllers;
 
 
+import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.controllers.dto.ConnectRequest;
+import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
+import com.savvato.tribeapp.dto.ConnectOutgoingMessageDTO;
 import com.savvato.tribeapp.services.ConnectService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -35,9 +41,8 @@ public class ConnectAPIController {
         }
     }
 
-    @RequestMapping(value = {"/api/connect/"}, method=RequestMethod.POST)
-    public boolean connect(@Valid ConnectRequest connectRequest){
-        boolean rtn = connectService.connect(connectRequest.requestingUserId, connectRequest.toBeConnectedWithUserId, connectRequest.qrcodePhrase);
-        return rtn;
+    @MessageMapping("/connect/room")
+    public void connect(@Payload ConnectIncomingMessageDTO incoming, UserPrincipal user, @Header("simpSessionId") String sessionId) {
+        connectService.connect(incoming, user);
     }
 }

--- a/src/main/java/com/savvato/tribeapp/dto/ConnectIncomingMessageDTO.java
+++ b/src/main/java/com/savvato/tribeapp/dto/ConnectIncomingMessageDTO.java
@@ -1,0 +1,13 @@
+package com.savvato.tribeapp.dto;
+
+import lombok.Builder;
+
+@Builder
+public class ConnectIncomingMessageDTO {
+    public Long requestingUserId;
+    public Long toBeConnectedWithUserId;
+
+    public String qrcodePhrase;
+
+    public String connectionIntent;
+}

--- a/src/main/java/com/savvato/tribeapp/dto/ConnectOutgoingMessageDTO.java
+++ b/src/main/java/com/savvato/tribeapp/dto/ConnectOutgoingMessageDTO.java
@@ -1,0 +1,16 @@
+package com.savvato.tribeapp.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public class ConnectOutgoingMessageDTO {
+    public Boolean connectionError;
+
+    public Boolean connectionSuccess;
+
+    public String  message;
+
+    public List<Long> to;
+}

--- a/src/main/java/com/savvato/tribeapp/services/ConnectService.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectService.java
@@ -16,5 +16,6 @@ public interface ConnectService {
     Boolean validateQRCode(String qrcodePhrase, Long toBeConnectedWithUserId);
     void connect(ConnectIncomingMessageDTO incoming, UserPrincipal user);
 
+    boolean saveConnectionDetails(Long requestingUserId, Long toBeConnectedWithUserId);
     ConnectOutgoingMessageDTO handleConnectionIntent(String connectionIntent, Long requestingUserId, Long toBeRequestedWithUserId);
 }

--- a/src/main/java/com/savvato/tribeapp/services/ConnectService.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectService.java
@@ -12,6 +12,8 @@ public interface ConnectService {
     Optional<String> getQRCodeString(long userId);
 
     Optional<String> storeQRCodeString(long userId);
+
+    Boolean validateQRCode(String qrcodePhrase, Long toBeConnectedWithUserId);
     void connect(ConnectIncomingMessageDTO incoming, UserPrincipal user);
 
     ConnectOutgoingMessageDTO handleConnectionIntent(String connectionIntent, Long requestingUserId, Long toBeRequestedWithUserId);

--- a/src/main/java/com/savvato/tribeapp/services/ConnectService.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectService.java
@@ -1,5 +1,9 @@
 package com.savvato.tribeapp.services;
 
+import com.savvato.tribeapp.config.principal.UserPrincipal;
+import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
+import org.springframework.messaging.handler.annotation.Header;
+
 import java.util.Optional;
 
 public interface ConnectService {
@@ -7,5 +11,5 @@ public interface ConnectService {
     Optional<String> getQRCodeString(long userId);
 
     Optional<String> storeQRCodeString(long userId);
-    boolean connect(Long requestingUserId, Long toBeConnectedWithUserId, String qrcodePhrase);
+    void connect(ConnectIncomingMessageDTO incoming, UserPrincipal user);
 }

--- a/src/main/java/com/savvato/tribeapp/services/ConnectService.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectService.java
@@ -2,6 +2,7 @@ package com.savvato.tribeapp.services;
 
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
+import com.savvato.tribeapp.dto.ConnectOutgoingMessageDTO;
 import org.springframework.messaging.handler.annotation.Header;
 
 import java.util.Optional;
@@ -12,4 +13,6 @@ public interface ConnectService {
 
     Optional<String> storeQRCodeString(long userId);
     void connect(ConnectIncomingMessageDTO incoming, UserPrincipal user);
+
+    ConnectOutgoingMessageDTO handleConnectionIntent(String connectionIntent, Long requestingUserId, Long toBeRequestedWithUserId);
 }

--- a/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
@@ -1,15 +1,23 @@
 package com.savvato.tribeapp.services;
 
+import com.savvato.tribeapp.config.principal.UserPrincipal;
+import com.savvato.tribeapp.controllers.dto.ConnectRequest;
+import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
+import com.savvato.tribeapp.dto.ConnectOutgoingMessageDTO;
 import com.savvato.tribeapp.entities.Connection;
 import com.savvato.tribeapp.repositories.ConnectionsRepository;
+import com.savvato.tribeapp.repositories.UserRepository;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
+
 @Service
 public class ConnectServiceImpl implements ConnectService {
 
@@ -17,7 +25,13 @@ public class ConnectServiceImpl implements ConnectService {
     CacheService cache;
 
     @Autowired
+    private SimpMessagingTemplate simpMessagingTemplate;
+
+    @Autowired
     ConnectionsRepository connectionsRepository;
+
+    @Autowired
+    UserRepository userRepository;
 
     private static final Log logger = LogFactory.getLog(ConnectServiceImpl.class);
 
@@ -49,17 +63,68 @@ public class ConnectServiceImpl implements ConnectService {
         return new String(digits);
     }
 
-    public boolean connect(Long requestingUserId, Long toBeConnectedWithUserId, String qrcodePhrase) {
-        if (qrcodePhrase == getQRCodeString(toBeConnectedWithUserId).get()) {
-            Optional<Connection> opt = Optional.of(connectionsRepository.save(new Connection(requestingUserId, toBeConnectedWithUserId)));
+    private boolean saveConnectionDetails(Long requestingUserId, Long toBeConnectedWithUserId) {
+        Optional<Connection> opt = Optional.of(connectionsRepository.save(new Connection(requestingUserId, toBeConnectedWithUserId)));
 
-            if (opt.isPresent()) {
-                return true;
+        if (opt.isPresent()) {
+            return true;
+        }
+        return false;
+    }
+
+    private Boolean validateQRCode(String qrcodePhrase, Long toBeConnectedWithUserId) {
+        return qrcodePhrase.equals(getQRCodeString(toBeConnectedWithUserId).get());
+    }
+
+    public void connect(ConnectIncomingMessageDTO incoming, UserPrincipal user) {
+        if(!validateQRCode(incoming.qrcodePhrase, incoming.toBeConnectedWithUserId)) {
+            ConnectOutgoingMessageDTO msg = ConnectOutgoingMessageDTO.builder()
+                                            .connectionError(true)
+                                            .message("Invalid QR code; failed to connect.")
+                                            .build();
+            simpMessagingTemplate.convertAndSendToUser(
+                    String.valueOf(incoming.toBeConnectedWithUserId),
+                    "/connect/user/queue/specific-user",
+                    msg);
+        } else {
+            ConnectOutgoingMessageDTO outgoingMsg = handleConnectionIntent(incoming.connectionIntent, incoming.requestingUserId, incoming.toBeConnectedWithUserId);
+            for (Long userId : outgoingMsg.to) {
+                simpMessagingTemplate.convertAndSendToUser(
+                        String.valueOf(userId),
+                        "/connect/user/queue/specific-user",
+                        outgoingMsg);
             }
-            return false;
         }
-        else {
-            return false;
+    }
+
+    private ConnectOutgoingMessageDTO handleConnectionIntent(String connectionIntent, Long requestingUserId, Long toBeConnectedWithUserId) {
+        if (connectionIntent == "") {
+            List<Long> recipients = new ArrayList<>(Arrays.asList(toBeConnectedWithUserId));
+            return ConnectOutgoingMessageDTO.builder().message("Please confirm that you wish to connect.").to(recipients).build();
+        } else {
+            if (connectionIntent == "confirmed") {
+                Boolean connectionStatus = saveConnectionDetails(requestingUserId, toBeConnectedWithUserId);
+
+                List<Long> recipients = new ArrayList<>(Arrays.asList(requestingUserId, toBeConnectedWithUserId));
+                if (connectionStatus) {
+                    return ConnectOutgoingMessageDTO.builder()
+                            .connectionSuccess(true)
+                            .to(recipients)
+                            .message("Successfully saved connection!").build();
+                } else {
+                    return ConnectOutgoingMessageDTO.builder()
+                            .connectionError(true)
+                            .to(recipients)
+                            .message("Failed to save connection to database.").build();
+                }
+            } else if (connectionIntent == "denied") {
+                List<Long> recipients = new ArrayList<>(Arrays.asList(requestingUserId, toBeConnectedWithUserId));
+                return ConnectOutgoingMessageDTO.builder()
+                        .connectionError(true)
+                        .to(recipients)
+                        .message("Connection request denied.").build();
+            }
         }
+        return null;
     }
 }

--- a/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
@@ -101,29 +101,27 @@ public class ConnectServiceImpl implements ConnectService {
         if (connectionIntent == "") {
             List<Long> recipients = new ArrayList<>(Arrays.asList(toBeConnectedWithUserId));
             return ConnectOutgoingMessageDTO.builder().message("Please confirm that you wish to connect.").to(recipients).build();
-        } else {
-            if (connectionIntent == "confirmed") {
-                Boolean connectionStatus = saveConnectionDetails(requestingUserId, toBeConnectedWithUserId);
-
-                List<Long> recipients = new ArrayList<>(Arrays.asList(requestingUserId, toBeConnectedWithUserId));
-                if (connectionStatus) {
-                    return ConnectOutgoingMessageDTO.builder()
-                            .connectionSuccess(true)
-                            .to(recipients)
-                            .message("Successfully saved connection!").build();
-                } else {
-                    return ConnectOutgoingMessageDTO.builder()
-                            .connectionError(true)
-                            .to(recipients)
-                            .message("Failed to save connection to database.").build();
-                }
-            } else if (connectionIntent == "denied") {
-                List<Long> recipients = new ArrayList<>(Arrays.asList(requestingUserId, toBeConnectedWithUserId));
+        } else if (connectionIntent == "confirmed") {
+            Boolean connectionStatus = saveConnectionDetails(requestingUserId, toBeConnectedWithUserId);
+            List<Long> recipients = new ArrayList<>(Arrays.asList(requestingUserId, toBeConnectedWithUserId));
+            if (connectionStatus) {
+                return ConnectOutgoingMessageDTO.builder()
+                        .connectionSuccess(true)
+                        .to(recipients)
+                        .message("Successfully saved connection!").build();
+            } else {
                 return ConnectOutgoingMessageDTO.builder()
                         .connectionError(true)
                         .to(recipients)
-                        .message("Connection request denied.").build();
+                        .message("Failed to save connection to database.").build();
             }
+        } else if (connectionIntent == "denied") {
+            List<Long> recipients = new ArrayList<>(Arrays.asList(requestingUserId, toBeConnectedWithUserId));
+            return ConnectOutgoingMessageDTO.builder()
+                    .connectionError(true)
+                    .to(recipients)
+                    .message("Connection request denied.").build();
+
         }
         return null;
     }

--- a/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
@@ -64,12 +64,14 @@ public class ConnectServiceImpl implements ConnectService {
     }
 
     public boolean saveConnectionDetails(Long requestingUserId, Long toBeConnectedWithUserId) {
-        Optional<Connection> opt = Optional.ofNullable(connectionsRepository.save(new Connection(requestingUserId, toBeConnectedWithUserId)));
-
-        if (opt.isPresent()) {
+        Optional<Connection> opt;
+        try {
+            connectionsRepository.save(new Connection(requestingUserId, toBeConnectedWithUserId));
             return true;
+        } catch (Exception e) {
+            return false;
         }
-        return false;
+
     }
 
     public Boolean validateQRCode(String qrcodePhrase, Long toBeConnectedWithUserId) {

--- a/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
@@ -64,7 +64,7 @@ public class ConnectServiceImpl implements ConnectService {
     }
 
     public boolean saveConnectionDetails(Long requestingUserId, Long toBeConnectedWithUserId) {
-        Optional<Connection> opt = Optional.of(connectionsRepository.save(new Connection(requestingUserId, toBeConnectedWithUserId)));
+        Optional<Connection> opt = Optional.ofNullable(connectionsRepository.save(new Connection(requestingUserId, toBeConnectedWithUserId)));
 
         if (opt.isPresent()) {
             return true;

--- a/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
@@ -63,7 +63,7 @@ public class ConnectServiceImpl implements ConnectService {
         return new String(digits);
     }
 
-    private boolean saveConnectionDetails(Long requestingUserId, Long toBeConnectedWithUserId) {
+    public boolean saveConnectionDetails(Long requestingUserId, Long toBeConnectedWithUserId) {
         Optional<Connection> opt = Optional.of(connectionsRepository.save(new Connection(requestingUserId, toBeConnectedWithUserId)));
 
         if (opt.isPresent()) {

--- a/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
@@ -72,7 +72,7 @@ public class ConnectServiceImpl implements ConnectService {
         return false;
     }
 
-    private Boolean validateQRCode(String qrcodePhrase, Long toBeConnectedWithUserId) {
+    public Boolean validateQRCode(String qrcodePhrase, Long toBeConnectedWithUserId) {
         return qrcodePhrase.equals(getQRCodeString(toBeConnectedWithUserId).get());
     }
 

--- a/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
@@ -78,6 +78,7 @@ public class ConnectServiceImpl implements ConnectService {
         return qrcodePhrase.equals(getQRCodeString(toBeConnectedWithUserId).get());
     }
 
+    @MessageMapping("/connect/room")
     public void connect(ConnectIncomingMessageDTO incoming, UserPrincipal user) {
         if(!validateQRCode(incoming.qrcodePhrase, incoming.toBeConnectedWithUserId)) {
             ConnectOutgoingMessageDTO msg = ConnectOutgoingMessageDTO.builder()

--- a/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
@@ -97,7 +97,7 @@ public class ConnectServiceImpl implements ConnectService {
         }
     }
 
-    private ConnectOutgoingMessageDTO handleConnectionIntent(String connectionIntent, Long requestingUserId, Long toBeConnectedWithUserId) {
+    public ConnectOutgoingMessageDTO handleConnectionIntent(String connectionIntent, Long requestingUserId, Long toBeConnectedWithUserId) {
         if (connectionIntent == "") {
             List<Long> recipients = new ArrayList<>(Arrays.asList(toBeConnectedWithUserId));
             return ConnectOutgoingMessageDTO.builder().message("Please confirm that you wish to connect.").to(recipients).build();

--- a/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
@@ -99,13 +99,45 @@ public class ConnectServiceImplTest extends AbstractServiceImplTest {
         ArgumentCaptor<String> recipientArg = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> destinationArg = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<ConnectOutgoingMessageDTO> outgoingMsgArg = ArgumentCaptor.forClass(ConnectOutgoingMessageDTO.class);
-        verify(simpMessagingTemplate, times(1)).convertAndSendToUser(recipientArg.capture(), destinationArg.capture(), outgoingMsgArg.capture());
 
+        verify(simpMessagingTemplate, times(1)).convertAndSendToUser(recipientArg.capture(), destinationArg.capture(), outgoingMsgArg.capture());
         assertEquals(recipientArg.getValue(), String.valueOf(toBeConnectedWithUserId));
         assertEquals(destinationArg.getValue(), expectedDestination);
         assertThat(outgoingMsgArg.getValue()).isEqualToComparingFieldByField(outgoing);
     }
 
+    @Test
+    public void connectWhenQrCodeIsValidAndNoConnectionIntentEstablished() {
+        UserPrincipal user = new UserPrincipal(getUser1());
+        Long requestingUserId = 1L;
+        Long toBeConnectedWithUserId = 2L;
+        String qrcodePhrase = "valid code";
+        String connectionIntent = "";
+        ArrayList<Long> recipients = new ArrayList<>(Arrays.asList(toBeConnectedWithUserId));
+        String expectedDestination = "/connect/user/queue/specific-user";
+        ConnectIncomingMessageDTO incoming = ConnectIncomingMessageDTO.builder().requestingUserId(requestingUserId).toBeConnectedWithUserId(toBeConnectedWithUserId).qrcodePhrase(qrcodePhrase).connectionIntent(connectionIntent).build();
+        ConnectOutgoingMessageDTO outgoing = ConnectOutgoingMessageDTO.builder().message("Please confirm that you wish to connect.").to(recipients).build();
+        ConnectService connectServiceSpy = spy(connectService);
+        doReturn(true).when(connectServiceSpy).validateQRCode(Mockito.any(), Mockito.any());
+        doReturn(outgoing).when(connectServiceSpy).handleConnectionIntent(Mockito.any(), Mockito.any(), Mockito.any());
 
+        connectServiceSpy.connect(incoming, user);
+
+        ArgumentCaptor<String> connectionIntentArg = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Long> requestingUserIdArg = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Long> toBeConnectedWithUserIdArg = ArgumentCaptor.forClass(Long.class);
+        verify(connectServiceSpy, times(1)).handleConnectionIntent(connectionIntentArg.capture(), requestingUserIdArg.capture(), toBeConnectedWithUserIdArg.capture());
+        assertEquals(connectionIntentArg.getValue(), connectionIntent);
+        assertEquals(requestingUserIdArg.getValue(), requestingUserId);
+        assertEquals(toBeConnectedWithUserIdArg.getValue(), toBeConnectedWithUserId);
+
+        ArgumentCaptor<String> recipientArg = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> destinationArg = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<ConnectOutgoingMessageDTO> outgoingMsgArg = ArgumentCaptor.forClass(ConnectOutgoingMessageDTO.class);
+        verify(simpMessagingTemplate, times(1)).convertAndSendToUser(recipientArg.capture(), destinationArg.capture(), outgoingMsgArg.capture());
+        assertEquals(recipientArg.getValue(), String.valueOf(toBeConnectedWithUserId));
+        assertEquals(destinationArg.getValue(), expectedDestination);
+        assertThat(outgoingMsgArg.getValue()).isEqualToComparingFieldByField(outgoing);
+    }
 
 }

--- a/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
@@ -153,4 +153,22 @@ public class ConnectServiceImplTest extends AbstractServiceImplTest {
         verify(connectServiceSpy, never()).saveConnectionDetails(Mockito.any(), Mockito.any());
         verify(connectionsRepository, never()).save(Mockito.any());
     }
+
+    @Test
+    public void handleConnectionIntentWhenConnectionIntentConfirmedAndDatabaseSaveSuccessful() {
+        Long requestingUserId = 1L;
+        Long toBeConnectedWithUserId = 2L;
+        String connectionIntent = "confirmed";
+        ArrayList<Long> recipients = new ArrayList<>(Arrays.asList(requestingUserId, toBeConnectedWithUserId));
+        ConnectOutgoingMessageDTO expectedOutgoingMsg = ConnectOutgoingMessageDTO.builder().connectionSuccess(true).to(recipients).message("Successfully saved connection!").build();
+        Connection connection = new Connection(requestingUserId, toBeConnectedWithUserId);
+        Mockito.when(connectionsRepository.save(Mockito.any())).thenReturn(connection);
+        ConnectOutgoingMessageDTO outgoing = connectService.handleConnectionIntent(connectionIntent, requestingUserId, toBeConnectedWithUserId);
+
+        ArgumentCaptor<Connection> connectionArg = ArgumentCaptor.forClass(Connection.class);
+        verify(connectionsRepository, times(1)).save(connectionArg.capture());
+        assertEquals(connectionArg.getValue().getToBeConnectedWithUserId(), toBeConnectedWithUserId);
+        assertEquals(connectionArg.getValue().getRequestingUserId(), requestingUserId);
+        assertThat(expectedOutgoingMsg.equals(outgoing));
+    }
 }

--- a/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
@@ -86,12 +86,12 @@ public class ConnectServiceImplTest extends AbstractServiceImplTest {
         Long requestingUserId = 1L;
         Long toBeConnectedWithUserId = 2L;
         String qrcodePhrase = "invalid code";
-        String expectedDestination = "/connect/user/queue/specific-user";
         String connectionIntent = "";
+        String expectedDestination = "/connect/user/queue/specific-user";
         ConnectIncomingMessageDTO incoming = ConnectIncomingMessageDTO.builder().requestingUserId(requestingUserId).toBeConnectedWithUserId(toBeConnectedWithUserId).qrcodePhrase(qrcodePhrase).connectionIntent(connectionIntent).build();
         ConnectOutgoingMessageDTO outgoing = ConnectOutgoingMessageDTO.builder().connectionError(true).message("Invalid QR code; failed to connect.").build();
         ConnectService connectServiceSpy = spy(connectService);
-        Mockito.when(cacheService.get(Mockito.any(), Mockito.any())).thenReturn("valid code");
+        doReturn(false).when(connectServiceSpy).validateQRCode(Mockito.any(), Mockito.any());
 
         connectServiceSpy.connect(incoming, user);
 


### PR DESCRIPTION
A websocket allows the frontend and backend to maintain realtime communication while the connection process is taking place. This pull request adds a Spring websocket in the backend. The ConnectWebSocketConfig file establishes a STOMP endpoint for the frontend to establish a connection to the websocket, and configures a Spring message broker to handle communication on the "/connect/user/queue/specific-user-{username}" destination. The ConnectService, implemented by ConnectServiceImpl, makes changes to the "connections" database table as needed and sends messages to the broker using SimpMessagingTemplate. DTOs are used to provide a uniform structure for incoming and outgoing messages.