### PR TITLE
TRIB 139 - Fix bug with toBeReviewed's toString() method

### DIFF
--- a/src/main/java/com/savvato/tribeapp/entities/ToBeReviewed.java
+++ b/src/main/java/com/savvato/tribeapp/entities/ToBeReviewed.java
@@ -64,14 +64,8 @@ public class ToBeReviewed {
     }
     @Override
     public String toString() {
-        String rtn = this.getVerb();
-        if (this.getPreposition() != "") {
-            rtn += " " + this.getPreposition();
-        }
-        rtn += " " + this.getNoun();
-        if (this.getAdverb() != "") {
-            rtn += " " + this.getAdverb();
-        }
+        String rtn = (this.getAdverb() != "") ? this.getAdverb() + " " + this.getVerb() : this.getVerb();
+        rtn += " " + ((this.getPreposition() != "") ? this.getPreposition() + " " + this.getNoun() : this.getNoun());
         return rtn;
     }
     @Id


### PR DESCRIPTION
Previously toBeReviewed's toString() method used to place adverbs at the end of the string that was generated. This pull request places adverbs at start of string, to match expected behavior.