### PR TITLE
TRIB 140: Refactor for ToBeReviewedCheckerServiceImpl

### DIFF
--- a/src/main/java/com/savvato/tribeapp/entities/RejectedPhrase.java
+++ b/src/main/java/com/savvato/tribeapp/entities/RejectedPhrase.java
@@ -17,6 +17,10 @@ public class RejectedPhrase {
         this.rejectedPhrase = rejectedPhrase;
     }
 
+    public RejectedPhrase(String rejectedPhrase) {
+        this.rejectedPhrase = rejectedPhrase;
+    }
+
     public RejectedPhrase() {
     }
 

--- a/src/main/java/com/savvato/tribeapp/repositories/RejectedPhraseRepository.java
+++ b/src/main/java/com/savvato/tribeapp/repositories/RejectedPhraseRepository.java
@@ -1,6 +1,7 @@
 package com.savvato.tribeapp.repositories;
 
 import com.savvato.tribeapp.entities.RejectedPhrase;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +12,7 @@ public interface RejectedPhraseRepository extends CrudRepository<RejectedPhrase,
     Optional<RejectedPhrase> findById(Long id);
 
     Optional<RejectedPhrase> findByRejectedPhrase(String rejectedPhrase);
+
+    @Query("INSERT IGNORE INTO rejected_phrase (rejected_phrase) VALUES (?1)")
+    RejectedPhrase save(String rejectedPhrase);
 }

--- a/src/main/java/com/savvato/tribeapp/repositories/RejectedPhraseRepository.java
+++ b/src/main/java/com/savvato/tribeapp/repositories/RejectedPhraseRepository.java
@@ -14,5 +14,5 @@ public interface RejectedPhraseRepository extends CrudRepository<RejectedPhrase,
     Optional<RejectedPhrase> findByRejectedPhrase(String rejectedPhrase);
 
     @Query("INSERT IGNORE INTO rejected_phrase (rejected_phrase) VALUES (?1)")
-    RejectedPhrase save(String rejectedPhrase);
+    RejectedPhrase save(RejectedPhrase rejectedPhrase);
 }

--- a/src/main/java/com/savvato/tribeapp/repositories/RejectedPhraseRepository.java
+++ b/src/main/java/com/savvato/tribeapp/repositories/RejectedPhraseRepository.java
@@ -13,6 +13,6 @@ public interface RejectedPhraseRepository extends CrudRepository<RejectedPhrase,
 
     Optional<RejectedPhrase> findByRejectedPhrase(String rejectedPhrase);
 
-    @Query("INSERT IGNORE INTO rejected_phrase (rejected_phrase) VALUES (?1)")
+    @Query(value = "INSERT IGNORE INTO rejected_phrase (rejected_phrase) VALUES (?1)", nativeQuery = true)
     RejectedPhrase save(RejectedPhrase rejectedPhrase);
 }

--- a/src/main/java/com/savvato/tribeapp/services/ToBeReviewedCheckerService.java
+++ b/src/main/java/com/savvato/tribeapp/services/ToBeReviewedCheckerService.java
@@ -11,7 +11,7 @@ public interface ToBeReviewedCheckerService {
 
     void validatePhrase(ToBeReviewed tbr);
 
-    void updateTables(ToBeReviewed tbr, boolean hasMatchingRejectedPhrase, boolean phraseValid);
+    void updateTables(ToBeReviewed tbr);
 
     JsonObject getWordDetails(String word);
 }

--- a/src/main/java/com/savvato/tribeapp/services/ToBeReviewedCheckerServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ToBeReviewedCheckerServiceImpl.java
@@ -93,28 +93,23 @@ public class ToBeReviewedCheckerServiceImpl implements ToBeReviewedCheckerServic
         if (matchingRejectedPhrase.isEmpty()) {
             boolean validPhrase = validatePhraseComponent(tbr.getNoun(), "noun") && validatePhraseComponent(tbr.getVerb(), "verb") && validatePhraseComponent(tbr.getAdverb(), "adverb") && validatePhraseComponent(tbr.getPreposition(), "preposition");
             if (validPhrase) {
-                updateTables(tbr, false, true);
+                toBeReviewedRepository.setHasBeenGroomedTrue(tbr.getId());
             } else {
                 LOGGER.warning("Phrase is invalid.");
-                updateTables(tbr, false, false);
+                updateTables(tbr);
             }
         }
         else {
             LOGGER.warning("Phrase has already been rejected!");
-            updateTables(tbr, true, false);
+            updateTables(tbr);
         }
     }
 
     @Override
-    public void updateTables(ToBeReviewed tbr, boolean hasMatchingRejectedPhrase, boolean phraseValid) {
-        if (phraseValid) {
-            toBeReviewedRepository.setHasBeenGroomedTrue(tbr.getId());
-        }
-        else {
-            rejectedPhraseRepository.save(new RejectedPhrase(tbr.toString()));
-            reviewSubmittingUserRepository.deleteByToBeReviewedId(tbr.getId());
-            toBeReviewedRepository.deleteById(tbr.getId());
-        }
+    public void updateTables(ToBeReviewed tbr) {
+        rejectedPhraseRepository.save(new RejectedPhrase(tbr.toString()));
+        reviewSubmittingUserRepository.deleteByToBeReviewedId(tbr.getId());
+        toBeReviewedRepository.deleteById(tbr.getId());
     }
 
 }

--- a/src/main/java/com/savvato/tribeapp/services/ToBeReviewedCheckerServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ToBeReviewedCheckerServiceImpl.java
@@ -111,11 +111,7 @@ public class ToBeReviewedCheckerServiceImpl implements ToBeReviewedCheckerServic
             toBeReviewedRepository.setHasBeenGroomedTrue(tbr.getId());
         }
         else {
-            if (!hasMatchingRejectedPhrase) {
-                RejectedPhrase rp = new RejectedPhrase();
-                rp.setRejectedPhrase(tbr.toString());
-                rejectedPhraseRepository.save(rp);
-            }
+            rejectedPhraseRepository.save(new RejectedPhrase(tbr.toString()));
             reviewSubmittingUserRepository.deleteByToBeReviewedId(tbr.getId());
             toBeReviewedRepository.deleteById(tbr.getId());
         }

--- a/src/main/resources/db/migration/changelog-202307250728.xml
+++ b/src/main/resources/db/migration/changelog-202307250728.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="maryam" id="202307250728-01">
+        <sql dbms="mysql">
+            ALTER TABLE rejected_phrase ADD UNIQUE(rejected_phrase);
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-master.xml
+++ b/src/main/resources/db/migration/changelog-master.xml
@@ -34,6 +34,7 @@
 	<include file="changelog-202305081206.xml" 	relativeToChangelogFile="true"/>
 	<include file="changelog-202305090846.xml" 	relativeToChangelogFile="true"/>
 	<include file="changelog-202305090856.xml" 	relativeToChangelogFile="true"/>
+	<include file="changelog-202307250728.xml" 	relativeToChangelogFile="true"/>
 
 </databaseChangeLog>
 

--- a/src/test/java/com/savvato/tribeapp/services/ToBeReviewedCheckerServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ToBeReviewedCheckerServiceImplTest.java
@@ -121,7 +121,7 @@ public class ToBeReviewedCheckerServiceImplTest {
     }
 
     @Test
-    public void updateTablesWhenPhraseValidAndNoMatchingRejectedPhrase() {
+    public void updateTablesWhenPhraseInvalidAndNoMatchingRejectedPhrase() {
         ToBeReviewed tbr = new ToBeReviewed(1L, false, "nonsense", "nonsense", "nonsense", "nonsense");
         boolean hasMatchingRejectedPhrase = false;
         boolean phraseValid = false;


### PR DESCRIPTION
Previously, ToBeReviewedCheckerServiceImpl's updateTables method contained an additional check to ensure that duplicates weren't inserted into the rejectedPhraseRepository.
```
    @Override
    public void updateTables(ToBeReviewed tbr, boolean hasMatchingRejectedPhrase, boolean phraseValid) {
        if (phraseValid) {
            toBeReviewedRepository.setHasBeenGroomedTrue(tbr.getId());
        }
        else {
            **if (!hasMatchingRejectedPhrase) {
                RejectedPhrase rp = new RejectedPhrase();
                rp.setRejectedPhrase(tbr.toString());
                rejectedPhraseRepository.save(rp);
            }**
            reviewSubmittingUserRepository.deleteByToBeReviewedId(tbr.getId());
            toBeReviewedRepository.deleteById(tbr.getId());
        }
    }
```
This PR eliminates the need for that check by:
-  placing a UNIQUE constraint on the rejected_phrase table's rejected_phrase column,
-  overriding rejectedPhraseRepository's save() method with a native query that uses INSERT IGNORE instead of INSERT to silently ignore duplication errors
