### PR TITLE
TRIB-144: Fix incorrect column name in ToBeReviewedRepository's findNextReviewEligible method

### DIFF
--- a/src/main/java/com/savvato/tribeapp/repositories/ToBeReviewedRepository.java
+++ b/src/main/java/com/savvato/tribeapp/repositories/ToBeReviewedRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 @Repository
 public interface ToBeReviewedRepository extends CrudRepository<ToBeReviewed, Long> {
-    @Query(nativeQuery = true, value = "select tbr.* from to_be_reviewed tbr where tbr.id>?1 and tbr.hasBeenGroomed=1")
+    @Query(nativeQuery = true, value = "select tbr.* from to_be_reviewed tbr where tbr.id>?1 and tbr.has_been_groomed=1")
     Optional<ToBeReviewed> findNextReviewEligible(Long id);
     @Query(nativeQuery = true, value = "select tbr.* from to_be_reviewed tbr where tbr.has_been_groomed=0")
     List<ToBeReviewed> getAllUngroomed();


### PR DESCRIPTION
Previously, the native query used in ToBeReviewedRepository's findNextReviewEligible method used the column name 'hasBeenGroomed'. This was a typo; the real column name is 'has_been_groomed'. This PR implements the correct column name in that native query.