### PR TITLE
Trib 150: bug fix saves "nullvalue" for blank adverb/preposition

### DIFF
--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -156,12 +156,11 @@ public class PhraseServiceImpl implements PhraseService {
                 toBeReviewed.setVerb(verbLowerCase);
                 toBeReviewed.setPreposition(prepositionLowerCase);
                 toBeReviewed.setNoun(nounLowerCase);
-                toBeReviewedRepository.save(toBeReviewed);
+                ToBeReviewed tbr = toBeReviewedRepository.save(toBeReviewed);
+
                 log.info("phrase added to to_be_reviewed table");
 
-                Optional<ToBeReviewed> toBeReviewedPhraseNew = toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(adverbLowerCase, verbLowerCase, nounLowerCase, prepositionLowerCase);
-
-                addUserAndPhraseToReviewSubmittingUserRepository(userId, toBeReviewedPhraseNew.get().getId());
+                addUserAndPhraseToReviewSubmittingUserRepository(userId, tbr.getId());
                 log.info("ToBeReviewed phrase has been mapped to user " + userId);
             }
 

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -128,9 +128,9 @@ public class PhraseServiceImpl implements PhraseService {
     @Override
     public void applyPhraseToUser(Long userId, String adverb, String verb, String preposition, String noun) {
 
-        String adverbLowerCase = changeToLowerCase(adverb);
+        String adverbLowerCase = adverb.isBlank() ? Constants.NULL_VALUE_WORD : changeToLowerCase(adverb);
         String verbLowerCase = changeToLowerCase(verb);
-        String prepositionLowerCase = changeToLowerCase(preposition);
+        String prepositionLowerCase = preposition.isBlank() ? Constants.NULL_VALUE_WORD : changeToLowerCase(preposition);
         String nounLowerCase = changeToLowerCase(noun);
 
         Optional<Long> previouslyReviewedPhraseId = findPreviouslyApprovedPhraseId(adverbLowerCase, verbLowerCase, prepositionLowerCase, nounLowerCase);
@@ -185,7 +185,7 @@ public class PhraseServiceImpl implements PhraseService {
             return Optional.empty();
         }
 
-        if (adverb == null || adverb.trim().isEmpty()) {
+        if (adverb.equals(Constants.NULL_VALUE_WORD)) {
             adverbId = Constants.NULL_VALUE_ID;
         } else if (findAdverbIfExists(adverb).isPresent()) {
             adverbId = adverbRepository.findByWord(adverb).get().getId();
@@ -193,7 +193,7 @@ public class PhraseServiceImpl implements PhraseService {
             return Optional.empty();
         }
 
-        if (preposition == null || preposition.trim().isEmpty()) {
+        if (preposition.equals(Constants.NULL_VALUE_WORD)) {
             prepositionId = Constants.NULL_VALUE_ID;
         } else if (findPrepositionIfExists(preposition).isPresent()) {
             prepositionId = prepositionRepository.findByWord(preposition).get().getId();

--- a/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
@@ -228,7 +228,7 @@ public class PhraseServiceImplTest extends AbstractServiceImplTest {
         ArgumentCaptor<String> argVerb = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> argPreposition = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> argNoun = ArgumentCaptor.forClass(String.class);
-        verify(toBeReviewedRepository, times(1)).findByAdverbAndVerbAndNounAndPreposition(argAdverb.capture(),argVerb.capture(),argPreposition.capture(),argNoun.capture());
+        verify(toBeReviewedRepository, times(1)).findByAdverbAndVerbAndNounAndPreposition(argAdverb.capture(),argVerb.capture(),argNoun.capture(),argPreposition.capture());
         assertEquals(argAdverb.getValue(), testAdverbConverted);
     }
 

--- a/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
@@ -231,4 +231,35 @@ public class PhraseServiceImplTest extends AbstractServiceImplTest {
         verify(toBeReviewedRepository, times(1)).findByAdverbAndVerbAndNounAndPreposition(argAdverb.capture(),argVerb.capture(),argPreposition.capture(),argNoun.capture());
         assertEquals(argAdverb.getValue(), testAdverbConverted);
     }
+
+    @Test
+    public void testApplyPhraseToUserWhenPrepositionIsBlank() {
+        User user1 = getUser1();
+        String testAdverb = getTestAdverb1().getWord();
+        String testVerb = getTestVerb1().getWord();
+        String testPreposition = "";
+        String testPrepositionConverted = "nullvalue";
+        String testNoun = getTestNoun1().getWord();
+
+        ToBeReviewed tbrSaved = new ToBeReviewed();
+        tbrSaved.setId(1L);
+        tbrSaved.setHasBeenGroomed(false);
+        tbrSaved.setAdverb(testAdverb);
+        tbrSaved.setVerb(testVerb);
+        tbrSaved.setPreposition(testPrepositionConverted);
+        tbrSaved.setNoun(testNoun);
+
+        // Should return false if the phrase has not been seen before
+        Mockito.when(toBeReviewedRepository.save(any())).thenReturn(tbrSaved);
+        boolean applyPhraseToUser = phraseService.applyPhraseToUser(user1.getId(),testAdverb,testVerb,testPreposition, testNoun);
+        assertFalse(applyPhraseToUser);
+
+        // Empty Preposition should be converted to "nullvalue"
+        ArgumentCaptor<String> argAdverb = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> argVerb = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> argPreposition = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> argNoun = ArgumentCaptor.forClass(String.class);
+        verify(toBeReviewedRepository, times(1)).findByAdverbAndVerbAndNounAndPreposition(argAdverb.capture(),argVerb.capture(),argNoun.capture(),argPreposition.capture());
+        assertEquals(argPreposition.getValue(), testPrepositionConverted);
+    }
 }

--- a/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
@@ -17,8 +17,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 
 @ExtendWith({SpringExtension.class})
@@ -200,5 +199,35 @@ public class PhraseServiceImplTest extends AbstractServiceImplTest {
 
         verify(reviewSubmittingUserRepository, times(1)).save(Mockito.any());
         assertFalse(rtn);
+    }
+
+    @Test
+    public void testApplyPhraseToUserWhenAdverbIsBlank() {
+        User user1 = getUser1();
+        String testAdverb = "";
+        String testAdverbConverted = "nullvalue";
+        String testVerb = getTestVerb1().getWord();
+        String testPreposition = getTestPreposition1().getWord();
+        String testNoun = getTestNoun1().getWord();
+
+        ToBeReviewed tbrSaved = new ToBeReviewed();
+        tbrSaved.setId(1L);
+        tbrSaved.setHasBeenGroomed(false);
+        tbrSaved.setAdverb(testAdverbConverted);
+        tbrSaved.setVerb(testVerb);
+        tbrSaved.setPreposition(testPreposition);
+        tbrSaved.setNoun(testNoun);
+
+        // Should return false if the phrase has not been seen before
+        Mockito.when(toBeReviewedRepository.save(any())).thenReturn(tbrSaved);
+        assertFalse(phraseService.applyPhraseToUser(user1.getId(),testAdverb,testVerb,testPreposition, testNoun));
+
+        // Empty Adverb should be converted to "nullvalue"
+        ArgumentCaptor<String> argAdverb = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> argVerb = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> argPreposition = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> argNoun = ArgumentCaptor.forClass(String.class);
+        verify(toBeReviewedRepository, times(1)).findByAdverbAndVerbAndNounAndPreposition(argAdverb.capture(),argVerb.capture(),argPreposition.capture(),argNoun.capture());
+        assertEquals(argAdverb.getValue(), testAdverbConverted);
     }
 }

--- a/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
@@ -193,7 +193,7 @@ public class PhraseServiceImplTest extends AbstractServiceImplTest {
 
         Mockito.when(phraseRepository.findByAdverbIdAndVerbIdAndPrepositionIdAndNounId(any(Long.class), any(Long.class), any(Long.class), any(Long.class))).thenReturn(Optional.empty());
 
-        Mockito.when(toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(anyString(), anyString(), anyString(),anyString())).thenReturn(Optional.empty()).thenReturn(Optional.of(toBeReviewed));
+        Mockito.when(toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(anyString(), anyString(), anyString(),anyString())).thenReturn(Optional.of(toBeReviewed));
 
         boolean rtn = phraseService.applyPhraseToUser(user1.getId(), testWord, testWord, testWord, testWord);
 

--- a/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
@@ -220,7 +220,8 @@ public class PhraseServiceImplTest extends AbstractServiceImplTest {
 
         // Should return false if the phrase has not been seen before
         Mockito.when(toBeReviewedRepository.save(any())).thenReturn(tbrSaved);
-        assertFalse(phraseService.applyPhraseToUser(user1.getId(),testAdverb,testVerb,testPreposition, testNoun));
+        boolean applyPhraseToUser = phraseService.applyPhraseToUser(user1.getId(),testAdverb,testVerb,testPreposition, testNoun);
+        assertFalse(applyPhraseToUser);
 
         // Empty Adverb should be converted to "nullvalue"
         ArgumentCaptor<String> argAdverb = ArgumentCaptor.forClass(String.class);


### PR DESCRIPTION
- updates applyPhraseToUser to save "nullvalue" in blank adverbs or prepositions in newly added phrases
- updates findPreviouslyApprovedPhraseId comparisons to check for "nullvalue" when building a phrase to search the phrase repo