### PR TITLE
Trib 161: AttributesAPIController returns empty string for "nullvalue" placeholder

### DIFF
--- a/src/main/java/com/savvato/tribeapp/services/AttributesServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/AttributesServiceImpl.java
@@ -2,7 +2,6 @@ package com.savvato.tribeapp.services;
 
 import com.savvato.tribeapp.dto.AttributeDTO;
 import com.savvato.tribeapp.dto.PhraseDTO;
-import com.savvato.tribeapp.repositories.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -22,7 +21,7 @@ public class AttributesServiceImpl implements AttributesService{
         List<AttributeDTO> attributes = new ArrayList<>();
 
         // Get all user phrases as phraseDTOs
-        Optional<List<PhraseDTO>> optUserPhraseDTOs = phraseService.getListOfPhraseDTOByUserId(userId);
+        Optional<List<PhraseDTO>> optUserPhraseDTOs = phraseService.getListOfPhraseDTOByUserIdWithoutPlaceholderNullvalue(userId);
 
         // If there are phrases, build DTO and add to attributes list
         if(optUserPhraseDTOs.isPresent()) {

--- a/src/main/java/com/savvato/tribeapp/services/PhraseService.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseService.java
@@ -13,5 +13,5 @@ public interface PhraseService {
 
     Optional<Long> findPreviouslyApprovedPhraseId(String adverb, String verb, String preposition, String noun);
 
-    Optional<List<PhraseDTO>> getListOfPhraseDTOByUserId(Long id);
+    Optional<List<PhraseDTO>> getListOfPhraseDTOByUserIdWithoutPlaceholderNullvalue(Long id);
 }

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -237,7 +237,7 @@ public class PhraseServiceImpl implements PhraseService {
     }
 
     @Override
-    public Optional<List<PhraseDTO>> getListOfPhraseDTOByUserId(Long userId) {
+    public Optional<List<PhraseDTO>> getListOfPhraseDTOByUserIdWithoutPlaceholderNullvalue(Long userId) {
 
         // create list of PhraseDtos
         List<PhraseDTO> phraseDTOS = new ArrayList<>();
@@ -260,7 +260,7 @@ public class PhraseServiceImpl implements PhraseService {
                 }
             }
 
-            // loop through phrases and get words
+            // loop through phrases and get words. replace nullvalue placeholders with empty string
             for (Phrase phrase : phrases) {
                 PhraseDTO phraseDTO = PhraseDTO.builder().build();
 
@@ -270,13 +270,15 @@ public class PhraseServiceImpl implements PhraseService {
                 Optional<String> optNoun = nounRepository.findNounById(phrase.getNounId());
 
                 if (optAdverb.isPresent()) {
-                    phraseDTO.adverb = optAdverb.get();
+                    String adverbText = optAdverb.get();
+                    phraseDTO.adverb = adverbText.equals(Constants.NULL_VALUE_WORD) ? "" : adverbText;
                 }
                 if (optVerb.isPresent()) {
                     phraseDTO.verb = optVerb.get();
                 }
                 if (optPreposition.isPresent()) {
-                    phraseDTO.preposition = optPreposition.get();
+                    String prepositionText = optPreposition.get();
+                    phraseDTO.preposition = prepositionText.equals(Constants.NULL_VALUE_WORD) ? "" : prepositionText;
                 }
                 if (optNoun.isPresent()) {
                     phraseDTO.noun = optNoun.get();

--- a/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/PhraseServiceImplTest.java
@@ -1,5 +1,7 @@
 package com.savvato.tribeapp.services;
 
+import com.savvato.tribeapp.constants.Constants;
+import com.savvato.tribeapp.dto.PhraseDTO;
 import com.savvato.tribeapp.entities.*;
 import com.savvato.tribeapp.repositories.*;
 import org.junit.jupiter.api.Test;
@@ -12,13 +14,15 @@ import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 
 @ExtendWith({SpringExtension.class})
@@ -200,5 +204,26 @@ public class PhraseServiceImplTest extends AbstractServiceImplTest {
 
         verify(reviewSubmittingUserRepository, times(1)).save(Mockito.any());
         assertFalse(rtn);
+    }
+
+    @Test
+    public void testGetListOfPhraseDTOByUserIdWithoutPlaceholderNullvalueForEmptyStrings() {
+        User user1 = getUser1();
+        String testWord = "test";
+        String testEmptyString = "";
+        List<Long> longList = new ArrayList<>(Arrays.asList(1L));
+        Phrase testPhrase = getTestPhrase1();
+
+        Mockito.when(userPhraseService.findPhraseIdsByUserId(anyLong())).thenReturn(Optional.of(longList));
+        Mockito.when(phraseRepository.findPhraseByPhraseId(anyLong())).thenReturn(Optional.of(testPhrase));
+        Mockito.when(adverbRepository.findAdverbById(anyLong())).thenReturn(Optional.of(Constants.NULL_VALUE_WORD));
+        Mockito.when(verbRepository.findVerbById(anyLong())).thenReturn(Optional.of(testWord));
+        Mockito.when(prepositionRepository.findPrepositionById(anyLong())).thenReturn(Optional.of(Constants.NULL_VALUE_WORD));
+        Mockito.when(nounRepository.findNounById(anyLong())).thenReturn(Optional.of(testWord));
+
+        Optional<List<PhraseDTO>> phraseDTOS = phraseService.getListOfPhraseDTOByUserIdWithoutPlaceholderNullvalue(user1.getId());
+        PhraseDTO phrase = phraseDTOS.get().get(0);
+        assertEquals(phrase.adverb,testEmptyString);
+        assertEquals(phrase.preposition,testEmptyString);
     }
 }


### PR DESCRIPTION
- Child issue ticket for TRIB-160
- Updates Phrase Service method getListOfPhraseDTOByUserIdWithoutPlaceholderNullvalue to new name and returns a PhraseDTO with empty strings for adverbs/prepositions that have "nullvalue" placeholders in the database


Testing
- compiles and runs
- works in postman
- added phrase service test testGetListOfPhraseDTOByUserIdWithoutPlaceholderNullvalueForEmptyStrings