### PR TITLE
Trib 162: updates ToBeReviewed service get review phrase method to return empty strings for any nullvalue placeholders

### DIFF
--- a/src/main/java/com/savvato/tribeapp/controllers/ToBeReviewedAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ToBeReviewedAPIController.java
@@ -24,7 +24,7 @@ public class ToBeReviewedAPIController {
 
     @GetMapping
     public ResponseEntity getPhrase() {
-        Optional<ToBeReviewed> opt = toBeReviewedService.getReviewPhraseWithoutPlaceholderNullvalue();
+        Optional<ToBeReviewed> opt = toBeReviewedService.getReviewPhrase();
 
         if (opt.isPresent()) {
             return ResponseEntity.status(HttpStatus.OK).body(opt.get());

--- a/src/main/java/com/savvato/tribeapp/controllers/ToBeReviewedAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ToBeReviewedAPIController.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Optional;
@@ -25,7 +24,7 @@ public class ToBeReviewedAPIController {
 
     @GetMapping
     public ResponseEntity getPhrase() {
-        Optional<ToBeReviewed> opt = toBeReviewedService.getReviewPhrase();
+        Optional<ToBeReviewed> opt = toBeReviewedService.getReviewPhraseWithoutPlaceholderNullvalue();
 
         if (opt.isPresent()) {
             return ResponseEntity.status(HttpStatus.OK).body(opt.get());

--- a/src/main/java/com/savvato/tribeapp/services/ToBeReviewedService.java
+++ b/src/main/java/com/savvato/tribeapp/services/ToBeReviewedService.java
@@ -5,7 +5,7 @@ import com.savvato.tribeapp.entities.ToBeReviewed;
 import java.util.Optional;
 
 public interface ToBeReviewedService {
-    Optional<ToBeReviewed> getReviewPhrase();
+    Optional<ToBeReviewed> getReviewPhraseWithoutPlaceholderNullvalue();
 
     void setLastAssignedForReview(Long id);
 

--- a/src/main/java/com/savvato/tribeapp/services/ToBeReviewedService.java
+++ b/src/main/java/com/savvato/tribeapp/services/ToBeReviewedService.java
@@ -5,7 +5,7 @@ import com.savvato.tribeapp.entities.ToBeReviewed;
 import java.util.Optional;
 
 public interface ToBeReviewedService {
-    Optional<ToBeReviewed> getReviewPhraseWithoutPlaceholderNullvalue();
+    Optional<ToBeReviewed> getReviewPhrase();
 
     void setLastAssignedForReview(Long id);
 

--- a/src/main/java/com/savvato/tribeapp/services/ToBeReviewedServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ToBeReviewedServiceImpl.java
@@ -20,7 +20,7 @@ public class ToBeReviewedServiceImpl implements ToBeReviewedService {
         this.lastAssignedForReviewId = id;
     }
     Long lastAssignedForReviewId = 0L;
-    public Optional<ToBeReviewed> getReviewPhrase() {
+    public Optional<ToBeReviewed> getReviewPhraseWithoutPlaceholderNullvalue() {
         Optional<ToBeReviewed> opt = toBeReviewedRepository.findNextReviewEligible(lastAssignedForReviewId);
         if (opt.isPresent()) {
             setLastAssignedForReview(opt.get().getId());

--- a/src/main/java/com/savvato/tribeapp/services/ToBeReviewedServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ToBeReviewedServiceImpl.java
@@ -1,5 +1,6 @@
 package com.savvato.tribeapp.services;
 
+import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.entities.ToBeReviewed;
 import com.savvato.tribeapp.repositories.ToBeReviewedRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,8 +24,15 @@ public class ToBeReviewedServiceImpl implements ToBeReviewedService {
     public Optional<ToBeReviewed> getReviewPhraseWithoutPlaceholderNullvalue() {
         Optional<ToBeReviewed> opt = toBeReviewedRepository.findNextReviewEligible(lastAssignedForReviewId);
         if (opt.isPresent()) {
-            setLastAssignedForReview(opt.get().getId());
-            return opt;
+            ToBeReviewed tbr = opt.get();
+            if(tbr.getAdverb().equals(Constants.NULL_VALUE_WORD)){
+                tbr.setAdverb("");
+            }
+            if(tbr.getPreposition().equals(Constants.NULL_VALUE_WORD)){
+                tbr.setPreposition("");
+            }
+            setLastAssignedForReview(tbr.getId());
+            return Optional.of(tbr);
         }
         return Optional.empty();
     }

--- a/src/main/java/com/savvato/tribeapp/services/ToBeReviewedServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ToBeReviewedServiceImpl.java
@@ -21,7 +21,7 @@ public class ToBeReviewedServiceImpl implements ToBeReviewedService {
         this.lastAssignedForReviewId = id;
     }
     Long lastAssignedForReviewId = 0L;
-    public Optional<ToBeReviewed> getReviewPhraseWithoutPlaceholderNullvalue() {
+    public Optional<ToBeReviewed> getReviewPhrase() {
         Optional<ToBeReviewed> opt = toBeReviewedRepository.findNextReviewEligible(lastAssignedForReviewId);
         if (opt.isPresent()) {
             ToBeReviewed tbr = opt.get();

--- a/src/test/java/com/savvato/tribeapp/services/ToBeReviewedServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ToBeReviewedServiceImplTest.java
@@ -47,7 +47,7 @@ public class ToBeReviewedServiceImplTest extends AbstractServiceImplTest {
 
         Mockito.when(toBeReviewedRepository.findNextReviewEligible(any(Long.class))).thenReturn(Optional.of(expectedToBeReviewed));
 
-        Optional<ToBeReviewed> rtn = toBeReviewedService.getReviewPhrase();
+        Optional<ToBeReviewed> rtn = toBeReviewedService.getReviewPhraseWithoutPlaceholderNullvalue();
 
         assertEquals(rtn.get(), expectedToBeReviewed);
         assertEquals(toBeReviewedService.getLastAssignedForReview(), expectedToBeReviewed.getId());
@@ -61,7 +61,7 @@ public class ToBeReviewedServiceImplTest extends AbstractServiceImplTest {
         Mockito.when(toBeReviewedRepository.findNextReviewEligible(any(Long.class))).thenReturn(Optional.empty());
 
         //Success: test that the getReviewPhrase() method returns an empty Optional object
-        assertFalse(toBeReviewedService.getReviewPhrase().isPresent());
+        assertFalse(toBeReviewedService.getReviewPhraseWithoutPlaceholderNullvalue().isPresent());
         
     }
 
@@ -79,7 +79,7 @@ public class ToBeReviewedServiceImplTest extends AbstractServiceImplTest {
 
         Mockito.when(toBeReviewedRepository.findNextReviewEligible(any(Long.class))).thenReturn(Optional.of(expectedToBeReviewed));
 
-        Optional<ToBeReviewed> rtn = toBeReviewedService.getReviewPhrase();
+        Optional<ToBeReviewed> rtn = toBeReviewedService.getReviewPhraseWithoutPlaceholderNullvalue();
 
         assertEquals(rtn.get(), expectedToBeReviewed);
         assertEquals(toBeReviewedService.getLastAssignedForReview(), expectedToBeReviewed.getId());
@@ -91,7 +91,7 @@ public class ToBeReviewedServiceImplTest extends AbstractServiceImplTest {
         expectedToBeReviewed.setPreposition("without");
         expectedToBeReviewed.setNoun("Scala");
 
-        Optional<ToBeReviewed> rtnTwo = toBeReviewedService.getReviewPhrase();
+        Optional<ToBeReviewed> rtnTwo = toBeReviewedService.getReviewPhraseWithoutPlaceholderNullvalue();
 
         assertEquals(rtnTwo.get(), expectedToBeReviewed);
         assertEquals(toBeReviewedService.getLastAssignedForReview(), expectedToBeReviewed.getId());

--- a/src/test/java/com/savvato/tribeapp/services/ToBeReviewedServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ToBeReviewedServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.savvato.tribeapp.services;
 
+import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.entities.ToBeReviewed;
 import com.savvato.tribeapp.repositories.ToBeReviewedRepository;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(SpringExtension.class)
@@ -95,5 +97,27 @@ public class ToBeReviewedServiceImplTest extends AbstractServiceImplTest {
 
         assertEquals(rtnTwo.get(), expectedToBeReviewed);
         assertEquals(toBeReviewedService.getLastAssignedForReview(), expectedToBeReviewed.getId());
+    }
+
+    @Test
+    public void testGetReviewPhraseWithoutPlaceholderNullvalueReturnsEmptyString() {
+        String testWord = "test";
+        String testEmptyString = "";
+
+        ToBeReviewed testTbr = new ToBeReviewed();
+        testTbr.setId(1L);
+        testTbr.setHasBeenGroomed(true);
+        testTbr.setAdverb(Constants.NULL_VALUE_WORD);
+        testTbr.setVerb(testWord);
+        testTbr.setPreposition(Constants.NULL_VALUE_WORD);
+        testTbr.setNoun(testWord);
+
+        Mockito.when(toBeReviewedRepository.findNextReviewEligible(anyLong())).thenReturn(Optional.of(testTbr));
+
+        Optional<ToBeReviewed> tbrOptional = toBeReviewedService.getReviewPhraseWithoutPlaceholderNullvalue();
+        ToBeReviewed tbr = tbrOptional.get();
+
+        assertEquals(tbr.getAdverb(),testEmptyString);
+        assertEquals(tbr.getPreposition(),testEmptyString);
     }
 }

--- a/src/test/java/com/savvato/tribeapp/services/ToBeReviewedServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ToBeReviewedServiceImplTest.java
@@ -49,7 +49,7 @@ public class ToBeReviewedServiceImplTest extends AbstractServiceImplTest {
 
         Mockito.when(toBeReviewedRepository.findNextReviewEligible(any(Long.class))).thenReturn(Optional.of(expectedToBeReviewed));
 
-        Optional<ToBeReviewed> rtn = toBeReviewedService.getReviewPhraseWithoutPlaceholderNullvalue();
+        Optional<ToBeReviewed> rtn = toBeReviewedService.getReviewPhrase();
 
         assertEquals(rtn.get(), expectedToBeReviewed);
         assertEquals(toBeReviewedService.getLastAssignedForReview(), expectedToBeReviewed.getId());
@@ -63,7 +63,7 @@ public class ToBeReviewedServiceImplTest extends AbstractServiceImplTest {
         Mockito.when(toBeReviewedRepository.findNextReviewEligible(any(Long.class))).thenReturn(Optional.empty());
 
         //Success: test that the getReviewPhrase() method returns an empty Optional object
-        assertFalse(toBeReviewedService.getReviewPhraseWithoutPlaceholderNullvalue().isPresent());
+        assertFalse(toBeReviewedService.getReviewPhrase().isPresent());
         
     }
 
@@ -81,7 +81,7 @@ public class ToBeReviewedServiceImplTest extends AbstractServiceImplTest {
 
         Mockito.when(toBeReviewedRepository.findNextReviewEligible(any(Long.class))).thenReturn(Optional.of(expectedToBeReviewed));
 
-        Optional<ToBeReviewed> rtn = toBeReviewedService.getReviewPhraseWithoutPlaceholderNullvalue();
+        Optional<ToBeReviewed> rtn = toBeReviewedService.getReviewPhrase();
 
         assertEquals(rtn.get(), expectedToBeReviewed);
         assertEquals(toBeReviewedService.getLastAssignedForReview(), expectedToBeReviewed.getId());
@@ -93,7 +93,7 @@ public class ToBeReviewedServiceImplTest extends AbstractServiceImplTest {
         expectedToBeReviewed.setPreposition("without");
         expectedToBeReviewed.setNoun("Scala");
 
-        Optional<ToBeReviewed> rtnTwo = toBeReviewedService.getReviewPhraseWithoutPlaceholderNullvalue();
+        Optional<ToBeReviewed> rtnTwo = toBeReviewedService.getReviewPhrase();
 
         assertEquals(rtnTwo.get(), expectedToBeReviewed);
         assertEquals(toBeReviewedService.getLastAssignedForReview(), expectedToBeReviewed.getId());
@@ -114,7 +114,7 @@ public class ToBeReviewedServiceImplTest extends AbstractServiceImplTest {
 
         Mockito.when(toBeReviewedRepository.findNextReviewEligible(anyLong())).thenReturn(Optional.of(testTbr));
 
-        Optional<ToBeReviewed> tbrOptional = toBeReviewedService.getReviewPhraseWithoutPlaceholderNullvalue();
+        Optional<ToBeReviewed> tbrOptional = toBeReviewedService.getReviewPhrase();
         ToBeReviewed tbr = tbrOptional.get();
 
         assertEquals(tbr.getAdverb(),testEmptyString);


### PR DESCRIPTION
- updates getReviewPhrase method name to getReviewPhraseWithoutPlaceholderNullvalue
- adds check for any adverb/preposition "nullvalue" placeholders from database and converts them to empty strings before returning to controller

Testing
- compiles and runs
- adds test to confirm "nullvalue" was replaced