### PR TITLE
TRIB-189: removes deprecated /changeLostPassword

### DIFF
--- a/src/main/java/com/savvato/tribeapp/controllers/UserAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/UserAPIController.java
@@ -88,11 +88,6 @@ public class UserAPIController {
 
 		return "{\"response\": true}";
 	}
-    // Deprecated Route moving to api/public/user/changePassword
-	@PostMapping( "/changeLostPassword" )
-	public UserDTO changeLostPassword(@RequestBody @Valid ChangePasswordRequest request) {
-		return userService.changePassword(request.pw, request.phoneNumber, request.smsChallengeCode);
-	}
 
 	@PostMapping( "/changePassword")
 	public UserDTO changePassword(@RequestBody @Valid ChangePasswordRequest request) {


### PR DESCRIPTION
(branched off develop)

- removes /changeLostPassword endpoint from User service
- TRIB-188 updates the frontend user service to route to /changePassword

Testing
- compiles and runs
- ran frontend/backend and verified that the profile page > edit > change password function worked