### PR TITLE
Trib 191: add DELETE endpoint to AttributesAPIController

### DIFF
--- a/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
@@ -1,5 +1,6 @@
 package com.savvato.tribeapp.controllers;
 
+import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPIController.ApplyPhraseToUser;
 import com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPIController.GetAttributesForUser;
 import com.savvato.tribeapp.controllers.dto.AttributesRequest;
@@ -8,6 +9,7 @@ import com.savvato.tribeapp.entities.NotificationType;
 import com.savvato.tribeapp.services.AttributesService;
 import com.savvato.tribeapp.services.NotificationService;
 import com.savvato.tribeapp.services.PhraseService;
+import com.savvato.tribeapp.services.UserPhraseService;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -16,6 +18,8 @@ import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -33,6 +37,9 @@ public class AttributesAPIController {
 
   @Autowired 
   NotificationService notificationService;
+
+  @Autowired
+  UserPhraseService userPhraseService;
 
   AttributesAPIController() {}
 
@@ -64,6 +71,18 @@ public class AttributesAPIController {
     } else {
       sendNotification(false, req.userId);
       return ResponseEntity.status(HttpStatus.OK).body(false);
+    }
+  }
+
+  @DeleteMapping
+  public ResponseEntity deletePhraseFromUser(@RequestParam Long phraseId) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication != null && authentication.getPrincipal() instanceof UserPrincipal) {
+      Long userId = ((UserPrincipal) authentication.getPrincipal()).getId();
+      userPhraseService.deletePhraseFromUser(phraseId, userId);
+      return ResponseEntity.ok().build();
+    } else {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("User not authenticated.");
     }
   }
 

--- a/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
@@ -1,7 +1,7 @@
 package com.savvato.tribeapp.controllers;
 
-import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPIController.ApplyPhraseToUser;
+import com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPIController.DeletePhraseFromUser;
 import com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPIController.GetAttributesForUser;
 import com.savvato.tribeapp.controllers.dto.AttributesRequest;
 import com.savvato.tribeapp.dto.AttributeDTO;
@@ -18,8 +18,6 @@ import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -74,16 +72,12 @@ public class AttributesAPIController {
     }
   }
 
+  ///api/attributes/?phraseId=xx&userId=xx
+  @DeletePhraseFromUser
   @DeleteMapping
-  public ResponseEntity deletePhraseFromUser(@RequestParam Long phraseId) {
-    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    if (authentication != null && authentication.getPrincipal() instanceof UserPrincipal) {
-      Long userId = ((UserPrincipal) authentication.getPrincipal()).getId();
+  public ResponseEntity deletePhraseFromUser(@Parameter(description = "Phrase ID of phrase", example = "1") @RequestParam("phraseId") Long phraseId, @Parameter(description = "User ID of user", example = "1") @RequestParam("userId") Long userId) {
       userPhraseService.deletePhraseFromUser(phraseId, userId);
       return ResponseEntity.ok().build();
-    } else {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("User not authenticated.");
-    }
   }
 
   private void sendNotification(Boolean approved, Long userId) {

--- a/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/AttributesAPIController/DeletePhraseFromUser.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/AttributesAPIController/DeletePhraseFromUser.java
@@ -1,0 +1,17 @@
+package com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPIController;
+
+import com.savvato.tribeapp.controllers.annotations.responses.Success;
+import io.swagger.v3.oas.annotations.Operation;
+
+import java.lang.annotation.*;
+
+/** Documentation for deleting a phrase association for a user */
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+    summary = "Delete association of this phrase from this user.",
+    description = "Provide a phrase ID, delete UserPhrase record from user_phrase table.")
+@Success(
+    description = "Successfully deleted UserPhrase.")
+public @interface DeletePhraseFromUser {}

--- a/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/AttributesAPIController/DeletePhraseFromUser.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/AttributesAPIController/DeletePhraseFromUser.java
@@ -13,5 +13,5 @@ import java.lang.annotation.*;
     summary = "Delete association of this phrase from this user.",
     description = "Provide a phrase ID, delete UserPhrase record from user_phrase table.")
 @Success(
-    description = "Successfully deleted UserPhrase.")
+    description = "Successfully deleted UserPhrase.", noContent = true)
 public @interface DeletePhraseFromUser {}

--- a/src/main/java/com/savvato/tribeapp/services/UserPhraseService.java
+++ b/src/main/java/com/savvato/tribeapp/services/UserPhraseService.java
@@ -6,4 +6,5 @@ import java.util.Optional;
 public interface UserPhraseService {
     Optional<List<Long>> findPhraseIdsByUserId(Long userId);
 
+    void deletePhraseFromUser(Long phraseId, Long userId);
 }

--- a/src/main/java/com/savvato/tribeapp/services/UserPhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/UserPhraseServiceImpl.java
@@ -1,5 +1,6 @@
 package com.savvato.tribeapp.services;
 
+import com.savvato.tribeapp.entities.UserPhraseId;
 import com.savvato.tribeapp.repositories.UserPhraseRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,15 @@ public class UserPhraseServiceImpl implements UserPhraseService{
 
         return optPhraseIdsForUser;
 
+    }
+
+    @Override
+    public void deletePhraseFromUser(Long phraseId, Long userId) {
+        UserPhraseId userPhraseId = new UserPhraseId();
+        userPhraseId.setPhraseId(phraseId);
+        userPhraseId.setUserId(userId);
+
+        userPhraseRepository.deleteById(userPhraseId);
     }
 
 }


### PR DESCRIPTION
- adds new endpoint deletePhraseFromUser to AttributesAPIController
- adds deletePhraseFromUser to UserPhraseService
- adds API Swagger annotation for deletePhraseFromUser

Testing:
- compiles and runs
- successfully deletes UserPhrase from UserPhrase table with Postman and Swagger UI

Note: AttributesAPIController test class does not exist. Maryam is nearly ready to submit TRIB-130, which may include this new class. I opted to forego creating a possible duplicate class. I can create another ticket specifically for creating a test for the delete endpoint (and creating the test class if needed). Awaiting confirmation from Maryam. 