### PR TITLE
TRIB-148: Improvements necessary for adequate test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,13 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.8</version>
+                <configuration>
+                    <excludes>
+                        <exclude>com/savvato/tribeapp/TribeAppApplication.class</exclude>
+                        <exclude>**/**/constants/**</exclude>
+                    </excludes>
+
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/com/savvato/tribeapp/controllers/annotations/config/builders/SchemaBuilder.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/annotations/config/builders/SchemaBuilder.java
@@ -3,31 +3,35 @@ package com.savvato.tribeapp.controllers.annotations.config.builders;
 import com.savvato.tribeapp.controllers.annotations.config.utils.SchemaUtils;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
+import lombok.Generated;
 import lombok.NoArgsConstructor;
 
-/** Builder class for OpenAPI schema model. */
+/**
+ * Builder class for OpenAPI schema model.
+ */
+@Generated
 @NoArgsConstructor
 public class SchemaBuilder extends ComposedSchema {
-  private Schema<?> schema;
+    private Schema<?> schema;
 
-  private Schema<?> getSchema() {
-    return this.schema;
-  }
+    private Schema<?> getSchema() {
+        return this.schema;
+    }
 
-  private void setSchema(Schema<?> newSchema) {
-    schema = newSchema;
-  }
+    private void setSchema(Schema<?> newSchema) {
+        schema = newSchema;
+    }
 
-  public Schema<?> build() {
-    if (schema != null && schema.getType() == null) schema.type("string");
-    return schema;
-  }
+    public Schema<?> build() {
+        if (schema != null && schema.getType() == null) schema.type("string");
+        return schema;
+    }
 
-  public void merge(Schema<?> patch) {
-    setSchema(SchemaUtils.mergeWithOverride(schema, patch));
-  }
+    public void merge(Schema<?> patch) {
+        setSchema(SchemaUtils.mergeWithOverride(schema, patch));
+    }
 
-  public static SchemaBuilder builder() {
-    return new SchemaBuilder();
-  }
+    public static SchemaBuilder builder() {
+        return new SchemaBuilder();
+    }
 }

--- a/src/main/java/com/savvato/tribeapp/controllers/annotations/config/utils/AnnotationsUtils.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/annotations/config/utils/AnnotationsUtils.java
@@ -5,12 +5,14 @@ import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.util.PrimitiveType;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Generated;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 
+@Generated
 public class AnnotationsUtils extends io.swagger.v3.core.util.AnnotationsUtils {
 
   /**

--- a/src/main/java/com/savvato/tribeapp/controllers/annotations/config/utils/RequestAnnotationUtils.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/annotations/config/utils/RequestAnnotationUtils.java
@@ -5,9 +5,11 @@ import com.savvato.tribeapp.controllers.annotations.requests.DocumentedRequestBo
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.models.media.MediaType;
 import java.util.Optional;
+import lombok.Generated;
 import org.apache.commons.lang3.StringUtils;
 import org.springdoc.core.fn.builders.schema.Builder;
 
+@Generated
 public class RequestAnnotationUtils extends AnnotationsUtils {
   private static final Builder SchemaAnnotationBuilder = Builder.schemaBuilder();
 

--- a/src/main/java/com/savvato/tribeapp/controllers/annotations/config/utils/ResponseAnnotationUtils.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/annotations/config/utils/ResponseAnnotationUtils.java
@@ -6,9 +6,11 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.models.media.MediaType;
 import java.util.Optional;
+import lombok.Generated;
 import org.apache.commons.lang3.StringUtils;
 import org.springdoc.core.fn.builders.schema.Builder;
 
+@Generated
 public class ResponseAnnotationUtils extends AnnotationsUtils {
   private static final Builder SchemaAnnotationBuilder = Builder.schemaBuilder();
 

--- a/src/main/java/com/savvato/tribeapp/services/SMSTextMessageService.java
+++ b/src/main/java/com/savvato/tribeapp/services/SMSTextMessageService.java
@@ -1,7 +1,14 @@
 package com.savvato.tribeapp.services;
 
+import com.plivo.api.models.message.MessageCreateResponse;
+
+import java.util.Optional;
+
 public interface SMSTextMessageService {
 
-	public boolean sendSMS(String toPhoneNumber, String msg);
-	
+    boolean sendSMS(String toPhoneNumber, String msg);
+
+    void initialize();
+
+    Optional<MessageCreateResponse> createResponse(String toPhoneNumber, String msg);
 }

--- a/src/main/java/com/savvato/tribeapp/services/SMSTextMessageServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/SMSTextMessageServiceImpl.java
@@ -1,52 +1,74 @@
 package com.savvato.tribeapp.services;
 
 import com.plivo.api.Plivo;
+import com.plivo.api.exceptions.PlivoRestException;
 import com.plivo.api.models.message.Message;
 import com.plivo.api.models.message.MessageCreateResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Optional;
 
 @Service
 @Slf4j
 public class SMSTextMessageServiceImpl implements SMSTextMessageService {
 
-	@Autowired
-	CacheService cache;
-	
-	@Value("${PLIVO_SMS_AUTH_ID}")
+    @Autowired
+    CacheService cache;
+
+    @Value("${PLIVO_SMS_AUTH_ID}")
     private String SMS_API_AUTH_ID;
 
-	@Value("${PLIVO_SMS_AUTH_TOKEN}")
+    @Value("${PLIVO_SMS_AUTH_TOKEN}")
     private String SMS_API_AUTH_TOKEN;
 
-	public boolean sendSMS(String toPhoneNumber, String msg) {
-		boolean rtn = false;
 
-		if (toPhoneNumber.startsWith("0")) {
-			rtn = true; 	// for use in testing. just act like we did it.
+    public void initialize() {
 
-			log.debug("PRETENDED to send SMS to " + toPhoneNumber + " /  msg: [" + msg + "]");
-		} else {
-			try {
-				log.debug(SMS_API_AUTH_ID);
-				log.debug(SMS_API_AUTH_TOKEN);
-				Plivo.init(SMS_API_AUTH_ID, SMS_API_AUTH_TOKEN);
-				MessageCreateResponse response = Message.creator("19342227693", toPhoneNumber, msg).create();
+        Plivo.init(SMS_API_AUTH_ID, SMS_API_AUTH_TOKEN);
+    }
 
-				log.debug("sms sent to " + toPhoneNumber + " /  msg: [" + msg + "]");
-				log.debug("sms response msg: " + response.getMessage());
+    public Optional<MessageCreateResponse> createResponse(String toPhoneNumber, String msg) {
+        try {
+            MessageCreateResponse response = Message.creator("19342227693", toPhoneNumber, msg).create();
+            return Optional.of(response);
+        } catch (PlivoRestException plivoRestException) {
+            log.debug("PlivoRestException occurred when trying to create response: " + plivoRestException.getMessage());
+        } catch (IOException ioException) {
+            log.debug("IOException occurred when trying to create response: " + ioException.getMessage());
+        }
+        return Optional.empty();
+    }
 
-				rtn = true;
+    public boolean sendSMS(String toPhoneNumber, String msg) {
+        boolean rtn = false;
 
-			} catch (Exception e) {
-				log.info("Caught exception trying to send SMS,  ------ " + e.getMessage());
-			}
-		}
+        if (toPhoneNumber.startsWith("0")) {
+            rtn = true;    // for use in testing. just act like we did it.
 
-		return rtn;
-	}
+            log.debug("PRETENDED to send SMS to " + toPhoneNumber + " /  msg: [" + msg + "]");
+        } else {
+            try {
+                log.debug(SMS_API_AUTH_ID);
+                log.debug(SMS_API_AUTH_TOKEN);
+                initialize();
+                Optional<MessageCreateResponse> responseOpt = createResponse(toPhoneNumber, msg);
+                if (responseOpt.isPresent()) {
+                    MessageCreateResponse response = responseOpt.get();
+
+                    log.debug("sms sent to " + toPhoneNumber + " /  msg: [" + msg + "]");
+                    log.debug("sms response msg: " + response.getMessage());
+                    rtn = true;
+                }
+
+            } catch (Exception e) {
+                log.info("Caught exception trying to send SMS,  ------ " + e.getMessage());
+            }
+        }
+
+        return rtn;
+    }
 }

--- a/src/main/java/com/savvato/tribeapp/services/SystemTimeProviderImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/SystemTimeProviderImpl.java
@@ -1,8 +1,11 @@
 package com.savvato.tribeapp.services;
 
+import lombok.Generated;
 import org.springframework.stereotype.Service;
+
 import java.time.Instant;
 
+@Generated
 @Service
 public class SystemTimeProviderImpl implements SystemTimeProvider {
 

--- a/src/test/java/com/savvato/tribeapp/services/ToBeReviewedCheckerServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ToBeReviewedCheckerServiceImplTest.java
@@ -2,36 +2,30 @@ package com.savvato.tribeapp.services;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.savvato.tribeapp.entities.*;
+import com.savvato.tribeapp.entities.RejectedPhrase;
+import com.savvato.tribeapp.entities.ReviewSubmittingUser;
+import com.savvato.tribeapp.entities.ToBeReviewed;
 import com.savvato.tribeapp.repositories.RejectedPhraseRepository;
 import com.savvato.tribeapp.repositories.ReviewSubmittingUserRepository;
 import com.savvato.tribeapp.repositories.ToBeReviewedRepository;
-import net.bytebuddy.asm.Advice;
-import org.codehaus.plexus.util.cli.Arg;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestTemplate;
 
-import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
-public class ToBeReviewedCheckerServiceImplTest extends AbstractServiceImplTest{
+public class ToBeReviewedCheckerServiceImplTest extends AbstractServiceImplTest {
     @TestConfiguration
     static class ToBeReviewedCheckerServiceImplTestContextConfiguration {
         @Bean
@@ -53,55 +47,77 @@ public class ToBeReviewedCheckerServiceImplTest extends AbstractServiceImplTest{
     @MockBean
     private ReviewSubmittingUserRepository reviewSubmittingUserRepository;
 
+    @MockBean
+    private RestTemplate restTemplate;
+
     @Test
     public void checkPartOfSpeech() {
         String word = "walk";
         String expectedPartOfSpeech = "verb";
-        JsonObject wordDetails = new JsonParser().parse("{\"word\":\"walk\",\"results\":[{\"definition\":\"the act of traveling by foot\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"walking\"],\"typeOf\":[\"locomotion\",\"travel\"],\"hasTypes\":[\"noctambulism\",\"march\",\"marching\",\"noctambulation\",\"plod\",\"plodding\",\"prowl\",\"shamble\",\"shambling\",\"shuffle\",\"shuffling\",\"sleepwalking\",\"somnambulation\",\"somnambulism\",\"wading\",\"ambulation\",\"gait\"],\"hasParts\":[\"pace\",\"tread\",\"stride\"],\"examples\":[\"walking is a healthy form of exercise\"]},{\"definition\":\"careers in general\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"walk of life\"],\"typeOf\":[\"calling\",\"career\",\"vocation\"],\"examples\":[\"it happens in all walks of life\"]},{\"definition\":\"take a walk; go for a walk; walk for pleasure\",\"partOfSpeech\":\"verb\",\"synonyms\":[\"take the air\"],\"typeOf\":[\"move\",\"locomote\",\"go\",\"travel\"],\"hasTypes\":[\"constitutionalize\"],\"examples\":[\"The lovers held hands while walking\",\"We like to walk every Sunday\"]},{\"definition\":\"manner of walking\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"manner of walking\"],\"typeOf\":[\"posture\",\"bearing\",\"carriage\"],\"examples\":[\"he had a funny walk\"]},{\"definition\":\"(baseball) an advance to first base by a batter who receives four balls\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"base on balls\",\"pass\"],\"inCategory\":[\"baseball\",\"baseball game\",\"ball\"],\"typeOf\":[\"achievement\",\"accomplishment\"]},{\"definition\":\"a path set aside for walking\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"paseo\",\"walkway\"],\"typeOf\":[\"path\"],\"hasTypes\":[\"sidewalk\",\"skywalk\",\"flagging\",\"ambulatory\",\"catwalk\",\"pavement\",\"promenade\",\"mall\",\"boardwalk\"],\"examples\":[\"after the blizzard he shoveled the front walk\"]},{\"definition\":\"accompany or escort\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"accompany\"],\"hasTypes\":[\"trot\",\"march\"],\"examples\":[\"I'll walk you to your car\"]},{\"definition\":\"a slow gait of a horse in which two feet are always on the ground\",\"partOfSpeech\":\"noun\",\"typeOf\":[\"gait\"]},{\"definition\":\"be or act in association with\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"consociate\",\"associate\"],\"examples\":[\"We must walk with our dispossessed brothers and sisters\"]},{\"definition\":\"give a base on balls to\",\"partOfSpeech\":\"verb\",\"inCategory\":[\"ball\",\"baseball game\",\"baseball\"],\"typeOf\":[\"play\"]},{\"definition\":\"live or behave in a specified manner\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"comport\",\"behave\"],\"examples\":[\"walk in sadness\"]},{\"definition\":\"make walk\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"oblige\",\"obligate\",\"compel\"],\"hasTypes\":[\"march\",\"exhibit\",\"parade\"],\"examples\":[\"He walks the horse up the mountain\"]},{\"definition\":\"obtain a base on balls\",\"partOfSpeech\":\"verb\",\"inCategory\":[\"baseball game\",\"baseball\",\"ball\"],\"typeOf\":[\"tally\",\"score\",\"hit\",\"rack up\"]},{\"definition\":\"the act of walking somewhere\",\"partOfSpeech\":\"noun\",\"typeOf\":[\"travelling\",\"traveling\",\"travel\"],\"hasTypes\":[\"foot\",\"walkabout\",\"walk-through\",\"turn\",\"moonwalk\",\"tramp\",\"stroll\",\"hiking\",\"amble\",\"saunter\",\"last mile\",\"promenade\",\"perambulation\",\"hike\",\"constitutional\"],\"examples\":[\"he took a walk after lunch\"]},{\"definition\":\"traverse or cover by walking\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"traverse\",\"cut across\",\"cut through\",\"cover\",\"track\",\"get across\",\"get over\",\"pass over\",\"cross\"],\"derivation\":[\"walker\"],\"examples\":[\"Paul walked the streets of Damascus\",\"She walks 3 miles every day\"]},{\"definition\":\"use one's feet to advance; advance by steps\",\"partOfSpeech\":\"verb\",\"entails\":[\"step\"],\"typeOf\":[\"go\",\"locomote\",\"travel\",\"move\"],\"hasTypes\":[\"walk around\",\"amble\",\"ambulate\",\"bumble\",\"careen\",\"clomp\",\"clump\",\"cock\",\"coggle\",\"creep\",\"dodder\",\"falter\",\"flounce\",\"flounder\",\"foot\",\"footslog\",\"gimp\",\"hike\",\"hitch\",\"hobble\",\"hoof\",\"hoof it\",\"keel\",\"leg it\",\"limp\",\"lollop\",\"lumber\",\"lurch\",\"march\",\"mince\",\"mosey\",\"mouse\",\"pace\",\"pad\",\"paddle\",\"perambulate\",\"plod\",\"pound\",\"prance\",\"process\",\"promenade\",\"prowl\",\"pussyfoot\",\"reel\",\"ruffle\",\"sashay\",\"saunter\",\"scuffle\",\"shamble\",\"shlep\",\"shuffle\",\"skulk\",\"sleepwalk\",\"slink\",\"slog\",\"slouch\",\"sneak\",\"somnambulate\",\"spacewalk\",\"stagger\",\"stalk\",\"stamp\",\"step\",\"stomp\",\"stride\",\"stroll\",\"strut\",\"stumble\",\"stump\",\"swag\",\"swagger\",\"tap\",\"tip\",\"tippytoe\",\"tiptoe\",\"tittup\",\"toddle\",\"toe\",\"totter\",\"traipse\",\"tramp\",\"tramp down\",\"trample\",\"tread\",\"tread down\",\"trudge\",\"waddle\",\"wade\",\"walk about\"],\"verbGroup\":[\"take the air\"],\"antonyms\":[\"ride\"],\"also\":[\"walk about\",\"walk around\"],\"derivation\":[\"walking\",\"walker\"],\"examples\":[\"We walked instead of driving\",\"She walks with a slight limp\",\"The patient cannot walk yet\"]},{\"definition\":\"walk at a pace\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"pace\"],\"examples\":[\"The horses walked across the meadow\"]}],\"syllables\":{\"count\":1,\"list\":[\"walk\"]},\"pronunciation\":{\"all\":\"wɔk\"},\"frequency\":5.3}").getAsJsonObject();
+        JsonObject wordDetails =
+                new JsonParser()
+                        .parse(
+                                "{\"word\":\"walk\",\"results\":[{\"definition\":\"the act of traveling by foot\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"walking\"],\"typeOf\":[\"locomotion\",\"travel\"],\"hasTypes\":[\"noctambulism\",\"march\",\"marching\",\"noctambulation\",\"plod\",\"plodding\",\"prowl\",\"shamble\",\"shambling\",\"shuffle\",\"shuffling\",\"sleepwalking\",\"somnambulation\",\"somnambulism\",\"wading\",\"ambulation\",\"gait\"],\"hasParts\":[\"pace\",\"tread\",\"stride\"],\"examples\":[\"walking is a healthy form of exercise\"]},{\"definition\":\"careers in general\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"walk of life\"],\"typeOf\":[\"calling\",\"career\",\"vocation\"],\"examples\":[\"it happens in all walks of life\"]},{\"definition\":\"take a walk; go for a walk; walk for pleasure\",\"partOfSpeech\":\"verb\",\"synonyms\":[\"take the air\"],\"typeOf\":[\"move\",\"locomote\",\"go\",\"travel\"],\"hasTypes\":[\"constitutionalize\"],\"examples\":[\"The lovers held hands while walking\",\"We like to walk every Sunday\"]},{\"definition\":\"manner of walking\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"manner of walking\"],\"typeOf\":[\"posture\",\"bearing\",\"carriage\"],\"examples\":[\"he had a funny walk\"]},{\"definition\":\"(baseball) an advance to first base by a batter who receives four balls\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"base on balls\",\"pass\"],\"inCategory\":[\"baseball\",\"baseball game\",\"ball\"],\"typeOf\":[\"achievement\",\"accomplishment\"]},{\"definition\":\"a path set aside for walking\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"paseo\",\"walkway\"],\"typeOf\":[\"path\"],\"hasTypes\":[\"sidewalk\",\"skywalk\",\"flagging\",\"ambulatory\",\"catwalk\",\"pavement\",\"promenade\",\"mall\",\"boardwalk\"],\"examples\":[\"after the blizzard he shoveled the front walk\"]},{\"definition\":\"accompany or escort\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"accompany\"],\"hasTypes\":[\"trot\",\"march\"],\"examples\":[\"I'll walk you to your car\"]},{\"definition\":\"a slow gait of a horse in which two feet are always on the ground\",\"partOfSpeech\":\"noun\",\"typeOf\":[\"gait\"]},{\"definition\":\"be or act in association with\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"consociate\",\"associate\"],\"examples\":[\"We must walk with our dispossessed brothers and sisters\"]},{\"definition\":\"give a base on balls to\",\"partOfSpeech\":\"verb\",\"inCategory\":[\"ball\",\"baseball game\",\"baseball\"],\"typeOf\":[\"play\"]},{\"definition\":\"live or behave in a specified manner\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"comport\",\"behave\"],\"examples\":[\"walk in sadness\"]},{\"definition\":\"make walk\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"oblige\",\"obligate\",\"compel\"],\"hasTypes\":[\"march\",\"exhibit\",\"parade\"],\"examples\":[\"He walks the horse up the mountain\"]},{\"definition\":\"obtain a base on balls\",\"partOfSpeech\":\"verb\",\"inCategory\":[\"baseball game\",\"baseball\",\"ball\"],\"typeOf\":[\"tally\",\"score\",\"hit\",\"rack up\"]},{\"definition\":\"the act of walking somewhere\",\"partOfSpeech\":\"noun\",\"typeOf\":[\"travelling\",\"traveling\",\"travel\"],\"hasTypes\":[\"foot\",\"walkabout\",\"walk-through\",\"turn\",\"moonwalk\",\"tramp\",\"stroll\",\"hiking\",\"amble\",\"saunter\",\"last mile\",\"promenade\",\"perambulation\",\"hike\",\"constitutional\"],\"examples\":[\"he took a walk after lunch\"]},{\"definition\":\"traverse or cover by walking\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"traverse\",\"cut across\",\"cut through\",\"cover\",\"track\",\"get across\",\"get over\",\"pass over\",\"cross\"],\"derivation\":[\"walker\"],\"examples\":[\"Paul walked the streets of Damascus\",\"She walks 3 miles every day\"]},{\"definition\":\"use one's feet to advance; advance by steps\",\"partOfSpeech\":\"verb\",\"entails\":[\"step\"],\"typeOf\":[\"go\",\"locomote\",\"travel\",\"move\"],\"hasTypes\":[\"walk around\",\"amble\",\"ambulate\",\"bumble\",\"careen\",\"clomp\",\"clump\",\"cock\",\"coggle\",\"creep\",\"dodder\",\"falter\",\"flounce\",\"flounder\",\"foot\",\"footslog\",\"gimp\",\"hike\",\"hitch\",\"hobble\",\"hoof\",\"hoof it\",\"keel\",\"leg it\",\"limp\",\"lollop\",\"lumber\",\"lurch\",\"march\",\"mince\",\"mosey\",\"mouse\",\"pace\",\"pad\",\"paddle\",\"perambulate\",\"plod\",\"pound\",\"prance\",\"process\",\"promenade\",\"prowl\",\"pussyfoot\",\"reel\",\"ruffle\",\"sashay\",\"saunter\",\"scuffle\",\"shamble\",\"shlep\",\"shuffle\",\"skulk\",\"sleepwalk\",\"slink\",\"slog\",\"slouch\",\"sneak\",\"somnambulate\",\"spacewalk\",\"stagger\",\"stalk\",\"stamp\",\"step\",\"stomp\",\"stride\",\"stroll\",\"strut\",\"stumble\",\"stump\",\"swag\",\"swagger\",\"tap\",\"tip\",\"tippytoe\",\"tiptoe\",\"tittup\",\"toddle\",\"toe\",\"totter\",\"traipse\",\"tramp\",\"tramp down\",\"trample\",\"tread\",\"tread down\",\"trudge\",\"waddle\",\"wade\",\"walk about\"],\"verbGroup\":[\"take the air\"],\"antonyms\":[\"ride\"],\"also\":[\"walk about\",\"walk around\"],\"derivation\":[\"walking\",\"walker\"],\"examples\":[\"We walked instead of driving\",\"She walks with a slight limp\",\"The patient cannot walk yet\"]},{\"definition\":\"walk at a pace\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"pace\"],\"examples\":[\"The horses walked across the meadow\"]}],\"syllables\":{\"count\":1,\"list\":[\"walk\"]},\"pronunciation\":{\"all\":\"wɔk\"},\"frequency\":5.3}")
+                        .getAsJsonObject();
         ToBeReviewedCheckerService toBeReviewedCheckerServiceSpy = spy(toBeReviewedCheckerService);
         doReturn(Optional.of(wordDetails)).when(toBeReviewedCheckerServiceSpy).getWordDetails(word);
         boolean rtn = toBeReviewedCheckerServiceSpy.checkPartOfSpeech(word, expectedPartOfSpeech);
-        assertEquals(rtn, true);
+        assertTrue(rtn);
     }
 
     @Test
     public void validatePhraseComponentWhenComponentIsValidNoun() {
         String word = "walk";
         String expectedPartOfSpeech = "noun";
-        JsonObject wordDetails = new JsonParser().parse("{\"word\":\"walk\",\"results\":[{\"definition\":\"the act of traveling by foot\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"walking\"],\"typeOf\":[\"locomotion\",\"travel\"],\"hasTypes\":[\"noctambulism\",\"march\",\"marching\",\"noctambulation\",\"plod\",\"plodding\",\"prowl\",\"shamble\",\"shambling\",\"shuffle\",\"shuffling\",\"sleepwalking\",\"somnambulation\",\"somnambulism\",\"wading\",\"ambulation\",\"gait\"],\"hasParts\":[\"pace\",\"tread\",\"stride\"],\"examples\":[\"walking is a healthy form of exercise\"]},{\"definition\":\"careers in general\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"walk of life\"],\"typeOf\":[\"calling\",\"career\",\"vocation\"],\"examples\":[\"it happens in all walks of life\"]},{\"definition\":\"take a walk; go for a walk; walk for pleasure\",\"partOfSpeech\":\"verb\",\"synonyms\":[\"take the air\"],\"typeOf\":[\"move\",\"locomote\",\"go\",\"travel\"],\"hasTypes\":[\"constitutionalize\"],\"examples\":[\"The lovers held hands while walking\",\"We like to walk every Sunday\"]},{\"definition\":\"manner of walking\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"manner of walking\"],\"typeOf\":[\"posture\",\"bearing\",\"carriage\"],\"examples\":[\"he had a funny walk\"]},{\"definition\":\"(baseball) an advance to first base by a batter who receives four balls\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"base on balls\",\"pass\"],\"inCategory\":[\"baseball\",\"baseball game\",\"ball\"],\"typeOf\":[\"achievement\",\"accomplishment\"]},{\"definition\":\"a path set aside for walking\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"paseo\",\"walkway\"],\"typeOf\":[\"path\"],\"hasTypes\":[\"sidewalk\",\"skywalk\",\"flagging\",\"ambulatory\",\"catwalk\",\"pavement\",\"promenade\",\"mall\",\"boardwalk\"],\"examples\":[\"after the blizzard he shoveled the front walk\"]},{\"definition\":\"accompany or escort\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"accompany\"],\"hasTypes\":[\"trot\",\"march\"],\"examples\":[\"I'll walk you to your car\"]},{\"definition\":\"a slow gait of a horse in which two feet are always on the ground\",\"partOfSpeech\":\"noun\",\"typeOf\":[\"gait\"]},{\"definition\":\"be or act in association with\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"consociate\",\"associate\"],\"examples\":[\"We must walk with our dispossessed brothers and sisters\"]},{\"definition\":\"give a base on balls to\",\"partOfSpeech\":\"verb\",\"inCategory\":[\"ball\",\"baseball game\",\"baseball\"],\"typeOf\":[\"play\"]},{\"definition\":\"live or behave in a specified manner\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"comport\",\"behave\"],\"examples\":[\"walk in sadness\"]},{\"definition\":\"make walk\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"oblige\",\"obligate\",\"compel\"],\"hasTypes\":[\"march\",\"exhibit\",\"parade\"],\"examples\":[\"He walks the horse up the mountain\"]},{\"definition\":\"obtain a base on balls\",\"partOfSpeech\":\"verb\",\"inCategory\":[\"baseball game\",\"baseball\",\"ball\"],\"typeOf\":[\"tally\",\"score\",\"hit\",\"rack up\"]},{\"definition\":\"the act of walking somewhere\",\"partOfSpeech\":\"noun\",\"typeOf\":[\"travelling\",\"traveling\",\"travel\"],\"hasTypes\":[\"foot\",\"walkabout\",\"walk-through\",\"turn\",\"moonwalk\",\"tramp\",\"stroll\",\"hiking\",\"amble\",\"saunter\",\"last mile\",\"promenade\",\"perambulation\",\"hike\",\"constitutional\"],\"examples\":[\"he took a walk after lunch\"]},{\"definition\":\"traverse or cover by walking\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"traverse\",\"cut across\",\"cut through\",\"cover\",\"track\",\"get across\",\"get over\",\"pass over\",\"cross\"],\"derivation\":[\"walker\"],\"examples\":[\"Paul walked the streets of Damascus\",\"She walks 3 miles every day\"]},{\"definition\":\"use one's feet to advance; advance by steps\",\"partOfSpeech\":\"verb\",\"entails\":[\"step\"],\"typeOf\":[\"go\",\"locomote\",\"travel\",\"move\"],\"hasTypes\":[\"walk around\",\"amble\",\"ambulate\",\"bumble\",\"careen\",\"clomp\",\"clump\",\"cock\",\"coggle\",\"creep\",\"dodder\",\"falter\",\"flounce\",\"flounder\",\"foot\",\"footslog\",\"gimp\",\"hike\",\"hitch\",\"hobble\",\"hoof\",\"hoof it\",\"keel\",\"leg it\",\"limp\",\"lollop\",\"lumber\",\"lurch\",\"march\",\"mince\",\"mosey\",\"mouse\",\"pace\",\"pad\",\"paddle\",\"perambulate\",\"plod\",\"pound\",\"prance\",\"process\",\"promenade\",\"prowl\",\"pussyfoot\",\"reel\",\"ruffle\",\"sashay\",\"saunter\",\"scuffle\",\"shamble\",\"shlep\",\"shuffle\",\"skulk\",\"sleepwalk\",\"slink\",\"slog\",\"slouch\",\"sneak\",\"somnambulate\",\"spacewalk\",\"stagger\",\"stalk\",\"stamp\",\"step\",\"stomp\",\"stride\",\"stroll\",\"strut\",\"stumble\",\"stump\",\"swag\",\"swagger\",\"tap\",\"tip\",\"tippytoe\",\"tiptoe\",\"tittup\",\"toddle\",\"toe\",\"totter\",\"traipse\",\"tramp\",\"tramp down\",\"trample\",\"tread\",\"tread down\",\"trudge\",\"waddle\",\"wade\",\"walk about\"],\"verbGroup\":[\"take the air\"],\"antonyms\":[\"ride\"],\"also\":[\"walk about\",\"walk around\"],\"derivation\":[\"walking\",\"walker\"],\"examples\":[\"We walked instead of driving\",\"She walks with a slight limp\",\"The patient cannot walk yet\"]},{\"definition\":\"walk at a pace\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"pace\"],\"examples\":[\"The horses walked across the meadow\"]}],\"syllables\":{\"count\":1,\"list\":[\"walk\"]},\"pronunciation\":{\"all\":\"wɔk\"},\"frequency\":5.3}").getAsJsonObject();
+        JsonObject wordDetails =
+                new JsonParser()
+                        .parse(
+                                "{\"word\":\"walk\",\"results\":[{\"definition\":\"the act of traveling by foot\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"walking\"],\"typeOf\":[\"locomotion\",\"travel\"],\"hasTypes\":[\"noctambulism\",\"march\",\"marching\",\"noctambulation\",\"plod\",\"plodding\",\"prowl\",\"shamble\",\"shambling\",\"shuffle\",\"shuffling\",\"sleepwalking\",\"somnambulation\",\"somnambulism\",\"wading\",\"ambulation\",\"gait\"],\"hasParts\":[\"pace\",\"tread\",\"stride\"],\"examples\":[\"walking is a healthy form of exercise\"]},{\"definition\":\"careers in general\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"walk of life\"],\"typeOf\":[\"calling\",\"career\",\"vocation\"],\"examples\":[\"it happens in all walks of life\"]},{\"definition\":\"take a walk; go for a walk; walk for pleasure\",\"partOfSpeech\":\"verb\",\"synonyms\":[\"take the air\"],\"typeOf\":[\"move\",\"locomote\",\"go\",\"travel\"],\"hasTypes\":[\"constitutionalize\"],\"examples\":[\"The lovers held hands while walking\",\"We like to walk every Sunday\"]},{\"definition\":\"manner of walking\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"manner of walking\"],\"typeOf\":[\"posture\",\"bearing\",\"carriage\"],\"examples\":[\"he had a funny walk\"]},{\"definition\":\"(baseball) an advance to first base by a batter who receives four balls\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"base on balls\",\"pass\"],\"inCategory\":[\"baseball\",\"baseball game\",\"ball\"],\"typeOf\":[\"achievement\",\"accomplishment\"]},{\"definition\":\"a path set aside for walking\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"paseo\",\"walkway\"],\"typeOf\":[\"path\"],\"hasTypes\":[\"sidewalk\",\"skywalk\",\"flagging\",\"ambulatory\",\"catwalk\",\"pavement\",\"promenade\",\"mall\",\"boardwalk\"],\"examples\":[\"after the blizzard he shoveled the front walk\"]},{\"definition\":\"accompany or escort\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"accompany\"],\"hasTypes\":[\"trot\",\"march\"],\"examples\":[\"I'll walk you to your car\"]},{\"definition\":\"a slow gait of a horse in which two feet are always on the ground\",\"partOfSpeech\":\"noun\",\"typeOf\":[\"gait\"]},{\"definition\":\"be or act in association with\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"consociate\",\"associate\"],\"examples\":[\"We must walk with our dispossessed brothers and sisters\"]},{\"definition\":\"give a base on balls to\",\"partOfSpeech\":\"verb\",\"inCategory\":[\"ball\",\"baseball game\",\"baseball\"],\"typeOf\":[\"play\"]},{\"definition\":\"live or behave in a specified manner\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"comport\",\"behave\"],\"examples\":[\"walk in sadness\"]},{\"definition\":\"make walk\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"oblige\",\"obligate\",\"compel\"],\"hasTypes\":[\"march\",\"exhibit\",\"parade\"],\"examples\":[\"He walks the horse up the mountain\"]},{\"definition\":\"obtain a base on balls\",\"partOfSpeech\":\"verb\",\"inCategory\":[\"baseball game\",\"baseball\",\"ball\"],\"typeOf\":[\"tally\",\"score\",\"hit\",\"rack up\"]},{\"definition\":\"the act of walking somewhere\",\"partOfSpeech\":\"noun\",\"typeOf\":[\"travelling\",\"traveling\",\"travel\"],\"hasTypes\":[\"foot\",\"walkabout\",\"walk-through\",\"turn\",\"moonwalk\",\"tramp\",\"stroll\",\"hiking\",\"amble\",\"saunter\",\"last mile\",\"promenade\",\"perambulation\",\"hike\",\"constitutional\"],\"examples\":[\"he took a walk after lunch\"]},{\"definition\":\"traverse or cover by walking\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"traverse\",\"cut across\",\"cut through\",\"cover\",\"track\",\"get across\",\"get over\",\"pass over\",\"cross\"],\"derivation\":[\"walker\"],\"examples\":[\"Paul walked the streets of Damascus\",\"She walks 3 miles every day\"]},{\"definition\":\"use one's feet to advance; advance by steps\",\"partOfSpeech\":\"verb\",\"entails\":[\"step\"],\"typeOf\":[\"go\",\"locomote\",\"travel\",\"move\"],\"hasTypes\":[\"walk around\",\"amble\",\"ambulate\",\"bumble\",\"careen\",\"clomp\",\"clump\",\"cock\",\"coggle\",\"creep\",\"dodder\",\"falter\",\"flounce\",\"flounder\",\"foot\",\"footslog\",\"gimp\",\"hike\",\"hitch\",\"hobble\",\"hoof\",\"hoof it\",\"keel\",\"leg it\",\"limp\",\"lollop\",\"lumber\",\"lurch\",\"march\",\"mince\",\"mosey\",\"mouse\",\"pace\",\"pad\",\"paddle\",\"perambulate\",\"plod\",\"pound\",\"prance\",\"process\",\"promenade\",\"prowl\",\"pussyfoot\",\"reel\",\"ruffle\",\"sashay\",\"saunter\",\"scuffle\",\"shamble\",\"shlep\",\"shuffle\",\"skulk\",\"sleepwalk\",\"slink\",\"slog\",\"slouch\",\"sneak\",\"somnambulate\",\"spacewalk\",\"stagger\",\"stalk\",\"stamp\",\"step\",\"stomp\",\"stride\",\"stroll\",\"strut\",\"stumble\",\"stump\",\"swag\",\"swagger\",\"tap\",\"tip\",\"tippytoe\",\"tiptoe\",\"tittup\",\"toddle\",\"toe\",\"totter\",\"traipse\",\"tramp\",\"tramp down\",\"trample\",\"tread\",\"tread down\",\"trudge\",\"waddle\",\"wade\",\"walk about\"],\"verbGroup\":[\"take the air\"],\"antonyms\":[\"ride\"],\"also\":[\"walk about\",\"walk around\"],\"derivation\":[\"walking\",\"walker\"],\"examples\":[\"We walked instead of driving\",\"She walks with a slight limp\",\"The patient cannot walk yet\"]},{\"definition\":\"walk at a pace\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"pace\"],\"examples\":[\"The horses walked across the meadow\"]}],\"syllables\":{\"count\":1,\"list\":[\"walk\"]},\"pronunciation\":{\"all\":\"wɔk\"},\"frequency\":5.3}")
+                        .getAsJsonObject();
 
         ToBeReviewedCheckerService toBeReviewedCheckerServiceSpy = spy(toBeReviewedCheckerService);
         doReturn(Optional.of(wordDetails)).when(toBeReviewedCheckerServiceSpy).getWordDetails(word);
-        doReturn(true).when(toBeReviewedCheckerServiceSpy).checkPartOfSpeech(word, expectedPartOfSpeech);
+        doReturn(true)
+                .when(toBeReviewedCheckerServiceSpy)
+                .checkPartOfSpeech(word, expectedPartOfSpeech);
 
         boolean rtn = toBeReviewedCheckerServiceSpy.checkPartOfSpeech(word, expectedPartOfSpeech);
-        assertEquals(rtn, true);
+        assertTrue(rtn);
     }
 
     @Test
     public void validatePhraseComponentWhenComponentIsIncorrectPartOfSpeech() {
         String word = "is";
         String expectedPartOfSpeech = "noun";
-        JsonObject wordDetails = new JsonParser().parse("{\"word\":\"is\",\"results\":[{\"definition\":\"the act of traveling by foot\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"walking\"],\"typeOf\":[\"locomotion\",\"travel\"],\"hasTypes\":[\"noctambulism\",\"march\",\"marching\",\"noctambulation\",\"plod\",\"plodding\",\"prowl\",\"shamble\",\"shambling\",\"shuffle\",\"shuffling\",\"sleepwalking\",\"somnambulation\",\"somnambulism\",\"wading\",\"ambulation\",\"gait\"],\"hasParts\":[\"pace\",\"tread\",\"stride\"],\"examples\":[\"walking is a healthy form of exercise\"]},{\"definition\":\"careers in general\",\"partOfSpeech\":\"verb\",\"synonyms\":[\"walk of life\"],\"typeOf\":[\"calling\",\"career\",\"vocation\"],\"examples\":[\"it happens in all walks of life\"]},{\"definition\":\"take a walk; go for a walk; walk for pleasure\",\"partOfSpeech\":\"verb\",\"synonyms\":[\"take the air\"],\"typeOf\":[\"move\",\"locomote\",\"go\",\"travel\"],\"hasTypes\":[\"constitutionalize\"],\"examples\":[\"The lovers held hands while walking\",\"We like to walk every Sunday\"]},{\"definition\":\"manner of walking\",\"partOfSpeech\":\"verb\",\"synonyms\":[\"manner of walking\"],\"typeOf\":[\"posture\",\"bearing\",\"carriage\"],\"examples\":[\"he had a funny walk\"]},{\"definition\":\"(baseball) an advance to first base by a batter who receives four balls\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"base on balls\",\"pass\"],\"inCategory\":[\"baseball\",\"baseball game\",\"ball\"],\"typeOf\":[\"achievement\",\"accomplishment\"]},{\"definition\":\"a path set aside for walking\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"paseo\",\"walkway\"],\"typeOf\":[\"path\"],\"hasTypes\":[\"sidewalk\",\"skywalk\",\"flagging\",\"ambulatory\",\"catwalk\",\"pavement\",\"promenade\",\"mall\",\"boardwalk\"],\"examples\":[\"after the blizzard he shoveled the front walk\"]},{\"definition\":\"accompany or escort\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"accompany\"],\"hasTypes\":[\"trot\",\"march\"],\"examples\":[\"I'll walk you to your car\"]},{\"definition\":\"a slow gait of a horse in which two feet are always on the ground\",\"partOfSpeech\":\"noun\",\"typeOf\":[\"gait\"]},{\"definition\":\"be or act in association with\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"consociate\",\"associate\"],\"examples\":[\"We must walk with our dispossessed brothers and sisters\"]},{\"definition\":\"give a base on balls to\",\"partOfSpeech\":\"verb\",\"inCategory\":[\"ball\",\"baseball game\",\"baseball\"],\"typeOf\":[\"play\"]},{\"definition\":\"live or behave in a specified manner\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"comport\",\"behave\"],\"examples\":[\"walk in sadness\"]},{\"definition\":\"make walk\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"oblige\",\"obligate\",\"compel\"],\"hasTypes\":[\"march\",\"exhibit\",\"parade\"],\"examples\":[\"He walks the horse up the mountain\"]},{\"definition\":\"obtain a base on balls\",\"partOfSpeech\":\"verb\",\"inCategory\":[\"baseball game\",\"baseball\",\"ball\"],\"typeOf\":[\"tally\",\"score\",\"hit\",\"rack up\"]},{\"definition\":\"the act of walking somewhere\",\"partOfSpeech\":\"noun\",\"typeOf\":[\"travelling\",\"traveling\",\"travel\"],\"hasTypes\":[\"foot\",\"walkabout\",\"walk-through\",\"turn\",\"moonwalk\",\"tramp\",\"stroll\",\"hiking\",\"amble\",\"saunter\",\"last mile\",\"promenade\",\"perambulation\",\"hike\",\"constitutional\"],\"examples\":[\"he took a walk after lunch\"]},{\"definition\":\"traverse or cover by walking\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"traverse\",\"cut across\",\"cut through\",\"cover\",\"track\",\"get across\",\"get over\",\"pass over\",\"cross\"],\"derivation\":[\"walker\"],\"examples\":[\"Paul walked the streets of Damascus\",\"She walks 3 miles every day\"]},{\"definition\":\"use one's feet to advance; advance by steps\",\"partOfSpeech\":\"verb\",\"entails\":[\"step\"],\"typeOf\":[\"go\",\"locomote\",\"travel\",\"move\"],\"hasTypes\":[\"walk around\",\"amble\",\"ambulate\",\"bumble\",\"careen\",\"clomp\",\"clump\",\"cock\",\"coggle\",\"creep\",\"dodder\",\"falter\",\"flounce\",\"flounder\",\"foot\",\"footslog\",\"gimp\",\"hike\",\"hitch\",\"hobble\",\"hoof\",\"hoof it\",\"keel\",\"leg it\",\"limp\",\"lollop\",\"lumber\",\"lurch\",\"march\",\"mince\",\"mosey\",\"mouse\",\"pace\",\"pad\",\"paddle\",\"perambulate\",\"plod\",\"pound\",\"prance\",\"process\",\"promenade\",\"prowl\",\"pussyfoot\",\"reel\",\"ruffle\",\"sashay\",\"saunter\",\"scuffle\",\"shamble\",\"shlep\",\"shuffle\",\"skulk\",\"sleepwalk\",\"slink\",\"slog\",\"slouch\",\"sneak\",\"somnambulate\",\"spacewalk\",\"stagger\",\"stalk\",\"stamp\",\"step\",\"stomp\",\"stride\",\"stroll\",\"strut\",\"stumble\",\"stump\",\"swag\",\"swagger\",\"tap\",\"tip\",\"tippytoe\",\"tiptoe\",\"tittup\",\"toddle\",\"toe\",\"totter\",\"traipse\",\"tramp\",\"tramp down\",\"trample\",\"tread\",\"tread down\",\"trudge\",\"waddle\",\"wade\",\"walk about\"],\"verbGroup\":[\"take the air\"],\"antonyms\":[\"ride\"],\"also\":[\"walk about\",\"walk around\"],\"derivation\":[\"walking\",\"walker\"],\"examples\":[\"We walked instead of driving\",\"She walks with a slight limp\",\"The patient cannot walk yet\"]},{\"definition\":\"walk at a pace\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"pace\"],\"examples\":[\"The horses walked across the meadow\"]}],\"syllables\":{\"count\":1,\"list\":[\"walk\"]},\"pronunciation\":{\"all\":\"wɔk\"},\"frequency\":5.3}").getAsJsonObject();
+        JsonObject wordDetails =
+                new JsonParser()
+                        .parse(
+                                "{\"word\":\"is\",\"results\":[{\"definition\":\"the act of traveling by foot\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"walking\"],\"typeOf\":[\"locomotion\",\"travel\"],\"hasTypes\":[\"noctambulism\",\"march\",\"marching\",\"noctambulation\",\"plod\",\"plodding\",\"prowl\",\"shamble\",\"shambling\",\"shuffle\",\"shuffling\",\"sleepwalking\",\"somnambulation\",\"somnambulism\",\"wading\",\"ambulation\",\"gait\"],\"hasParts\":[\"pace\",\"tread\",\"stride\"],\"examples\":[\"walking is a healthy form of exercise\"]},{\"definition\":\"careers in general\",\"partOfSpeech\":\"verb\",\"synonyms\":[\"walk of life\"],\"typeOf\":[\"calling\",\"career\",\"vocation\"],\"examples\":[\"it happens in all walks of life\"]},{\"definition\":\"take a walk; go for a walk; walk for pleasure\",\"partOfSpeech\":\"verb\",\"synonyms\":[\"take the air\"],\"typeOf\":[\"move\",\"locomote\",\"go\",\"travel\"],\"hasTypes\":[\"constitutionalize\"],\"examples\":[\"The lovers held hands while walking\",\"We like to walk every Sunday\"]},{\"definition\":\"manner of walking\",\"partOfSpeech\":\"verb\",\"synonyms\":[\"manner of walking\"],\"typeOf\":[\"posture\",\"bearing\",\"carriage\"],\"examples\":[\"he had a funny walk\"]},{\"definition\":\"(baseball) an advance to first base by a batter who receives four balls\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"base on balls\",\"pass\"],\"inCategory\":[\"baseball\",\"baseball game\",\"ball\"],\"typeOf\":[\"achievement\",\"accomplishment\"]},{\"definition\":\"a path set aside for walking\",\"partOfSpeech\":\"noun\",\"synonyms\":[\"paseo\",\"walkway\"],\"typeOf\":[\"path\"],\"hasTypes\":[\"sidewalk\",\"skywalk\",\"flagging\",\"ambulatory\",\"catwalk\",\"pavement\",\"promenade\",\"mall\",\"boardwalk\"],\"examples\":[\"after the blizzard he shoveled the front walk\"]},{\"definition\":\"accompany or escort\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"accompany\"],\"hasTypes\":[\"trot\",\"march\"],\"examples\":[\"I'll walk you to your car\"]},{\"definition\":\"a slow gait of a horse in which two feet are always on the ground\",\"partOfSpeech\":\"noun\",\"typeOf\":[\"gait\"]},{\"definition\":\"be or act in association with\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"consociate\",\"associate\"],\"examples\":[\"We must walk with our dispossessed brothers and sisters\"]},{\"definition\":\"give a base on balls to\",\"partOfSpeech\":\"verb\",\"inCategory\":[\"ball\",\"baseball game\",\"baseball\"],\"typeOf\":[\"play\"]},{\"definition\":\"live or behave in a specified manner\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"comport\",\"behave\"],\"examples\":[\"walk in sadness\"]},{\"definition\":\"make walk\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"oblige\",\"obligate\",\"compel\"],\"hasTypes\":[\"march\",\"exhibit\",\"parade\"],\"examples\":[\"He walks the horse up the mountain\"]},{\"definition\":\"obtain a base on balls\",\"partOfSpeech\":\"verb\",\"inCategory\":[\"baseball game\",\"baseball\",\"ball\"],\"typeOf\":[\"tally\",\"score\",\"hit\",\"rack up\"]},{\"definition\":\"the act of walking somewhere\",\"partOfSpeech\":\"noun\",\"typeOf\":[\"travelling\",\"traveling\",\"travel\"],\"hasTypes\":[\"foot\",\"walkabout\",\"walk-through\",\"turn\",\"moonwalk\",\"tramp\",\"stroll\",\"hiking\",\"amble\",\"saunter\",\"last mile\",\"promenade\",\"perambulation\",\"hike\",\"constitutional\"],\"examples\":[\"he took a walk after lunch\"]},{\"definition\":\"traverse or cover by walking\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"traverse\",\"cut across\",\"cut through\",\"cover\",\"track\",\"get across\",\"get over\",\"pass over\",\"cross\"],\"derivation\":[\"walker\"],\"examples\":[\"Paul walked the streets of Damascus\",\"She walks 3 miles every day\"]},{\"definition\":\"use one's feet to advance; advance by steps\",\"partOfSpeech\":\"verb\",\"entails\":[\"step\"],\"typeOf\":[\"go\",\"locomote\",\"travel\",\"move\"],\"hasTypes\":[\"walk around\",\"amble\",\"ambulate\",\"bumble\",\"careen\",\"clomp\",\"clump\",\"cock\",\"coggle\",\"creep\",\"dodder\",\"falter\",\"flounce\",\"flounder\",\"foot\",\"footslog\",\"gimp\",\"hike\",\"hitch\",\"hobble\",\"hoof\",\"hoof it\",\"keel\",\"leg it\",\"limp\",\"lollop\",\"lumber\",\"lurch\",\"march\",\"mince\",\"mosey\",\"mouse\",\"pace\",\"pad\",\"paddle\",\"perambulate\",\"plod\",\"pound\",\"prance\",\"process\",\"promenade\",\"prowl\",\"pussyfoot\",\"reel\",\"ruffle\",\"sashay\",\"saunter\",\"scuffle\",\"shamble\",\"shlep\",\"shuffle\",\"skulk\",\"sleepwalk\",\"slink\",\"slog\",\"slouch\",\"sneak\",\"somnambulate\",\"spacewalk\",\"stagger\",\"stalk\",\"stamp\",\"step\",\"stomp\",\"stride\",\"stroll\",\"strut\",\"stumble\",\"stump\",\"swag\",\"swagger\",\"tap\",\"tip\",\"tippytoe\",\"tiptoe\",\"tittup\",\"toddle\",\"toe\",\"totter\",\"traipse\",\"tramp\",\"tramp down\",\"trample\",\"tread\",\"tread down\",\"trudge\",\"waddle\",\"wade\",\"walk about\"],\"verbGroup\":[\"take the air\"],\"antonyms\":[\"ride\"],\"also\":[\"walk about\",\"walk around\"],\"derivation\":[\"walking\",\"walker\"],\"examples\":[\"We walked instead of driving\",\"She walks with a slight limp\",\"The patient cannot walk yet\"]},{\"definition\":\"walk at a pace\",\"partOfSpeech\":\"verb\",\"typeOf\":[\"pace\"],\"examples\":[\"The horses walked across the meadow\"]}],\"syllables\":{\"count\":1,\"list\":[\"walk\"]},\"pronunciation\":{\"all\":\"wɔk\"},\"frequency\":5.3}")
+                        .getAsJsonObject();
 
         ToBeReviewedCheckerService toBeReviewedCheckerServiceSpy = spy(toBeReviewedCheckerService);
         doReturn(Optional.of(wordDetails)).when(toBeReviewedCheckerServiceSpy).getWordDetails(word);
-        doReturn(false).when(toBeReviewedCheckerServiceSpy).checkPartOfSpeech(word, expectedPartOfSpeech);
+        doReturn(false)
+                .when(toBeReviewedCheckerServiceSpy)
+                .checkPartOfSpeech(word, expectedPartOfSpeech);
 
         boolean rtn = toBeReviewedCheckerServiceSpy.checkPartOfSpeech(word, expectedPartOfSpeech);
-        assertEquals(rtn, false);
+        assertFalse(rtn);
     }
 
     @Test
     public void validatePhraseWhenPhraseValid() {
         ToBeReviewed tbr = new ToBeReviewed(1L, false, "competitively", "plays", "", "chess");
         ToBeReviewedCheckerService toBeReviewedCheckerServiceSpy = spy(toBeReviewedCheckerService);
-        doReturn(true).when(toBeReviewedCheckerServiceSpy).checkPartOfSpeech(Mockito.any(), Mockito.any());
-        Mockito.when(rejectedPhraseRepository.findByRejectedPhrase(Mockito.any())).thenReturn(Optional.empty());
+        doReturn(true)
+                .when(toBeReviewedCheckerServiceSpy)
+                .checkPartOfSpeech(Mockito.any(), Mockito.any());
+        Mockito.when(rejectedPhraseRepository.findByRejectedPhrase(Mockito.any()))
+                .thenReturn(Optional.empty());
         toBeReviewedCheckerServiceSpy.validatePhrase(tbr);
 
         // verify tbr was groomed
-        assertEquals(true,tbr.isHasBeenGroomed());
+        assertEquals(true, tbr.isHasBeenGroomed());
 
         verify(rejectedPhraseRepository, times(0)).save(Mockito.any());
         verify(reviewSubmittingUserRepository, times(0)).delete(Mockito.any());
@@ -111,7 +127,8 @@ public class ToBeReviewedCheckerServiceImplTest extends AbstractServiceImplTest{
     @Test
     public void updateTablesWhenPhraseInvalidAndNoMatchingRejectedPhrase() {
         ToBeReviewed tbr = new ToBeReviewed(1L, false, "nonsense", "nonsense", "nonsense", "nonsense");
-        Mockito.when(reviewSubmittingUserRepository.findUserIdByToBeReviewedId(Mockito.any())).thenReturn(USER1_ID);
+        Mockito.when(reviewSubmittingUserRepository.findUserIdByToBeReviewedId(Mockito.any()))
+                .thenReturn(USER1_ID);
 
         toBeReviewedCheckerService.updateTables(tbr);
 
@@ -123,13 +140,12 @@ public class ToBeReviewedCheckerServiceImplTest extends AbstractServiceImplTest{
         verify(reviewSubmittingUserRepository, times(1)).delete(arg2.capture());
         assertEquals(arg2.getValue().getUserId(), USER1_ID);
 
-
         ArgumentCaptor<Long> arg3 = ArgumentCaptor.forClass(Long.class);
         verify(toBeReviewedRepository, times(1)).deleteById(arg3.capture());
         assertEquals(arg3.getValue(), tbr.getId());
 
         // verify tbr was not groomed
-        assertEquals(false,tbr.isHasBeenGroomed());
+        assertEquals(false, tbr.isHasBeenGroomed());
     }
 
     @Test
@@ -137,14 +153,17 @@ public class ToBeReviewedCheckerServiceImplTest extends AbstractServiceImplTest{
         ToBeReviewed tbr = new ToBeReviewed(1L, false, "competitively", "plays", "", "chess");
 
         ToBeReviewedCheckerService toBeReviewedCheckerServiceSpy = spy(toBeReviewedCheckerService);
-        Mockito.when(rejectedPhraseRepository.findByRejectedPhrase(Mockito.any())).thenReturn(Optional.empty());
-        doReturn(true).when(toBeReviewedCheckerServiceSpy).checkPartOfSpeech(Mockito.any(), Mockito.any());
+        Mockito.when(rejectedPhraseRepository.findByRejectedPhrase(Mockito.any()))
+                .thenReturn(Optional.empty());
+        doReturn(true)
+                .when(toBeReviewedCheckerServiceSpy)
+                .checkPartOfSpeech(Mockito.any(), Mockito.any());
 
         toBeReviewedCheckerServiceSpy.validatePhrase(tbr);
         ArgumentCaptor<Long> arg1 = ArgumentCaptor.forClass(Long.class);
 
         // verify tbr was groomed
-        assertEquals(true,tbr.isHasBeenGroomed());
+        assertEquals(true, tbr.isHasBeenGroomed());
     }
 
     @Test
@@ -153,7 +172,11 @@ public class ToBeReviewedCheckerServiceImplTest extends AbstractServiceImplTest{
         String expectedPartOfSpeech = "verb";
 
         // Known example of error from Words API as of 08/22/23
-        JsonObject wordDetails = new JsonParser().parse("{\"rhymes\":{\"all\": \"-eɪkeɪʃ\"},\"word\":\"bakes\",\"pronunciation\":\"beɪks\",\"frequency\":2.78}").getAsJsonObject();
+        JsonObject wordDetails =
+                new JsonParser()
+                        .parse(
+                                "{\"rhymes\":{\"all\": \"-eɪkeɪʃ\"},\"word\":\"bakes\",\"pronunciation\":\"beɪks\",\"frequency\":2.78}")
+                        .getAsJsonObject();
 
         ToBeReviewedCheckerService toBeReviewedCheckerServiceSpy = spy(toBeReviewedCheckerService);
         doReturn(Optional.of(wordDetails)).when(toBeReviewedCheckerServiceSpy).getWordDetails(word);
@@ -168,7 +191,11 @@ public class ToBeReviewedCheckerServiceImplTest extends AbstractServiceImplTest{
         String expectedPartOfSpeech = "adverb";
 
         // Known example of error from Words API as of 08/22/23
-        JsonObject wordDetails = new JsonParser().parse("{\"word\":\"competitively\",\"results\":[{\"definition\":\"in competition\",\"partOfSpeech\":null,\"antonyms\":[\"noncompetitively\"],\"pertainsTo\":[\"competitive\"],\"examples\":[\"the companies ld bid competitively\"]}],\"syllables\":{\"count\":5,\"list\":[\"com\",\"pet\",\"i\",\"tive\",\"ly\"]},\"pronunciation\":{\"all\":\"kəm'pɛtɪtɪvli\"},\"frequency\":2.03}").getAsJsonObject();
+        JsonObject wordDetails =
+                new JsonParser()
+                        .parse(
+                                "{\"word\":\"competitively\",\"results\":[{\"definition\":\"in competition\",\"partOfSpeech\":null,\"antonyms\":[\"noncompetitively\"],\"pertainsTo\":[\"competitive\"],\"examples\":[\"the companies ld bid competitively\"]}],\"syllables\":{\"count\":5,\"list\":[\"com\",\"pet\",\"i\",\"tive\",\"ly\"]},\"pronunciation\":{\"all\":\"kəm'pɛtɪtɪvli\"},\"frequency\":2.03}")
+                        .getAsJsonObject();
 
         ToBeReviewedCheckerService toBeReviewedCheckerServiceSpy = spy(toBeReviewedCheckerService);
         doReturn(Optional.of(wordDetails)).when(toBeReviewedCheckerServiceSpy).getWordDetails(word);
@@ -177,4 +204,22 @@ public class ToBeReviewedCheckerServiceImplTest extends AbstractServiceImplTest{
         assertTrue(rtn);
     }
 
+    @Test
+    public void updatesTablesIfPhraseInvalid() {
+        ToBeReviewed tbr = new ToBeReviewed(1L, false, "competitively", "plays", "", "chess");
+        ToBeReviewedCheckerService toBeReviewedCheckerServiceSpy = spy(toBeReviewedCheckerService);
+        doReturn(false)
+                .when(toBeReviewedCheckerServiceSpy)
+                .checkPartOfSpeech(Mockito.any(), Mockito.any());
+        Mockito.when(rejectedPhraseRepository.findByRejectedPhrase(Mockito.any()))
+                .thenReturn(Optional.empty());
+        toBeReviewedCheckerServiceSpy.validatePhrase(tbr);
+        ArgumentCaptor<ToBeReviewed> toBeReviewedArgumentCaptor =
+                ArgumentCaptor.forClass(ToBeReviewed.class);
+
+        verify(toBeReviewedRepository, times(0)).save(Mockito.any());
+        verify(toBeReviewedCheckerServiceSpy, times(1))
+                .updateTables(toBeReviewedArgumentCaptor.capture());
+        assertEquals(toBeReviewedArgumentCaptor.getValue(), tbr);
+    }
 }


### PR DESCRIPTION
This is part of [TRIB-148: Increase coverage to 50%](https://mockprogrammingjob.atlassian.net/browse/TRIB-148?atlOrigin=eyJpIjoiNjNlMDg3OGU3NTQ0NDkzZWIwNTAxMjBjYmM1YTdhNTUiLCJwIjoiaiJ9).
There are certain services that are implemented in a way that makes it difficult to test them. To achieve better coverage, they need to be tweaked slightly. These are the changes this PR makes:

- Autowire RestTemplate in ToBeReviewedCheckerServiceImpl instead of initializing it inside a method, so it can be mocked
- Separate sendSMS in SMSTextMessageService into 3 methods:
  - initialize, which initializes Plivo
  - createResponse, which creates the response
  - sendSMS, which actually sends the message
  This allows Plivo's initialization to be mocked and allows unit tests to be more granular.
- Exclude the following from coverage:
  - Swagger-documentation tools
  - Main class
  - Constants
  - SystemTimeProvider
    - This class cannot be tested, as it is simply used to get the current instant using Instant.now().