### PR TITLE
TRIB-148: Fix faulty logic

### DIFF
--- a/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
@@ -10,76 +10,79 @@ import com.savvato.tribeapp.services.NotificationService;
 import com.savvato.tribeapp.services.PhraseService;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
-import java.util.Optional;
-import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+import java.util.List;
+import java.util.Optional;
+
 @RestController
 @RequestMapping("/api/attributes")
 @Tag(
-    name = "attributes",
-    description = "Everything about attributes, e.g. \"plays chess competitively\"")
+        name = "attributes",
+        description = "Everything about attributes, e.g. \"plays chess competitively\"")
 public class AttributesAPIController {
 
-  @Autowired 
-  AttributesService attributesService;
+    @Autowired
+    AttributesService attributesService;
 
-  @Autowired
-  PhraseService phraseService;
+    @Autowired
+    PhraseService phraseService;
 
-  @Autowired 
-  NotificationService notificationService;
+    @Autowired
+    NotificationService notificationService;
 
-  AttributesAPIController() {}
-
-  @GetAttributesForUser
-  @GetMapping("/{userId}")
-  public ResponseEntity<List<AttributeDTO>> getAttributesForUser(
-      @Parameter(description = "User ID of user", example = "1") @PathVariable Long userId) {
-
-    Optional<List<AttributeDTO>> opt = attributesService.getAttributesByUserId(userId);
-
-    if (opt.isPresent()) return ResponseEntity.status(HttpStatus.OK).body(opt.get());
-    else return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
-  }
-
-  @ApplyPhraseToUser
-  @PostMapping
-  public ResponseEntity<Boolean> applyPhraseToUser(@RequestBody @Valid AttributesRequest req) {
-    if (phraseService.isPhraseValid(req.adverb, req.verb, req.preposition, req.noun)) {
-      boolean isPhraseApplied =
-          phraseService.applyPhraseToUser(
-              req.userId, req.adverb, req.verb, req.preposition, req.noun);
-      if (isPhraseApplied) {
-        sendNotification(true, req.userId);
-        return ResponseEntity.status(HttpStatus.OK).body(true);
-      } else {
-        sendNotification(false, req.userId);
-        return ResponseEntity.status(HttpStatus.OK).body(false);
-      }
-    } else {
-      sendNotification(false, req.userId);
-      return ResponseEntity.status(HttpStatus.OK).body(false);
+    AttributesAPIController() {
     }
-  }
 
-  private void sendNotification(Boolean approved, Long userId) {
-    if (approved) {
-      notificationService.createNotification(
-          NotificationType.ATTRIBUTE_REQUEST_REJECTED,
-          userId,
-          NotificationType.ATTRIBUTE_REQUEST_REJECTED.getName(),
-          "Your attribute was rejected. This attribute is unsuitable and cannot be applied to users.");
-    } else {
-      notificationService.createNotification(
-          NotificationType.ATTRIBUTE_REQUEST_APPROVED,
-          userId,
-          NotificationType.ATTRIBUTE_REQUEST_APPROVED.getName(),
-          "Your attribute has been approved!");
+    @GetAttributesForUser
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<AttributeDTO>> getAttributesForUser(
+            @Parameter(description = "User ID of user", example = "1") @PathVariable Long userId) {
+
+        Optional<List<AttributeDTO>> opt = attributesService.getAttributesByUserId(userId);
+
+        if (opt.isPresent()) return ResponseEntity.status(HttpStatus.OK).body(opt.get());
+        else return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
     }
-  }
+
+    @ApplyPhraseToUser
+    @PostMapping
+    public ResponseEntity<Boolean> applyPhraseToUser(@RequestBody @Valid AttributesRequest req) {
+        if (phraseService.isPhraseValid(req.adverb, req.verb, req.preposition, req.noun)) {
+            boolean isPhraseApplied =
+                    phraseService.applyPhraseToUser(
+                            req.userId, req.adverb, req.verb, req.preposition, req.noun);
+            if (isPhraseApplied) {
+                sendNotification(true, req.userId);
+                return ResponseEntity.status(HttpStatus.OK).body(true);
+            } else {
+                sendNotification(false, req.userId);
+                return ResponseEntity.status(HttpStatus.OK).body(false);
+            }
+        } else {
+            sendNotification(false, req.userId);
+            return ResponseEntity.status(HttpStatus.OK).body(false);
+        }
+    }
+
+    private void sendNotification(Boolean approved, Long userId) {
+        if (approved) {
+            notificationService.createNotification(
+                    NotificationType.ATTRIBUTE_REQUEST_APPROVED,
+                    userId,
+                    NotificationType.ATTRIBUTE_REQUEST_APPROVED.getName(),
+                    "Your attribute has been approved!");
+        } else {
+            notificationService.createNotification(
+                    NotificationType.ATTRIBUTE_REQUEST_REJECTED,
+                    userId,
+                    NotificationType.ATTRIBUTE_REQUEST_REJECTED.getName(),
+                    "Your attribute was rejected. This attribute is unsuitable and cannot be applied to users.");
+
+        }
+    }
 }

--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -1,6 +1,5 @@
 package com.savvato.tribeapp.controllers;
 
-import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController.Connect;
 import com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController.GetQRCodeString;
 import com.savvato.tribeapp.controllers.dto.ConnectRequest;
@@ -8,8 +7,6 @@ import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
 import com.savvato.tribeapp.services.ConnectService;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.Optional;
-import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,48 +15,49 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+import java.util.Optional;
+
 @RestController
 @Tag(name = "connect", description = "Connections between users")
 @RequestMapping("/api/connect")
 public class ConnectAPIController {
-  @Autowired ConnectService connectService;
+    @Autowired
+    ConnectService connectService;
 
-  ConnectAPIController() {}
-
-  @GetQRCodeString
-  @GetMapping("/{userId}")
-  public ResponseEntity getQrCodeString(
-      @Parameter(description = "The user ID of a user", example = "1") @PathVariable Long userId) {
-
-    Optional<String> opt = connectService.storeQRCodeString(userId);
-
-    if (opt.isPresent()) {
-      return ResponseEntity.status(HttpStatus.OK).body(opt.get());
-    } else {
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+    ConnectAPIController() {
     }
-  }
 
-  @Connect
-  @PostMapping
-  public boolean connect(@Valid ConnectRequest connectRequest) {
-    if (connectService.validateQRCode(
-        connectRequest.qrcodePhrase, connectRequest.toBeConnectedWithUserId)) {
-      boolean isConnectionSaved =
-          connectService.saveConnectionDetails(
-              connectRequest.requestingUserId, connectRequest.toBeConnectedWithUserId);
-      if (isConnectionSaved) {
-        return true;
-      } else {
-        return false;
-      }
-    } else {
-      return false;
+    @GetQRCodeString
+    @GetMapping("/{userId}")
+    public ResponseEntity getQrCodeString(
+            @Parameter(description = "The user ID of a user", example = "1") @PathVariable Long userId) {
+
+        Optional<String> opt = connectService.storeQRCodeString(userId);
+
+        if (opt.isPresent()) {
+            return ResponseEntity.status(HttpStatus.OK).body(opt.get());
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        }
     }
-  }
 
-  @MessageMapping("/connect/room")
-  public void connect(@Payload ConnectIncomingMessageDTO incoming, @Header("simpSessionId") String sessionId) {
-      connectService.connect(incoming);
-  }
+    @Connect
+    @PostMapping
+    public boolean connect(@Valid @RequestBody ConnectRequest connectRequest) {
+        if (connectService.validateQRCode(
+                connectRequest.qrcodePhrase, connectRequest.toBeConnectedWithUserId)) {
+            boolean isConnectionSaved =
+                    connectService.saveConnectionDetails(
+                            connectRequest.requestingUserId, connectRequest.toBeConnectedWithUserId);
+          return isConnectionSaved;
+        } else {
+            return false;
+        }
+    }
+
+    @MessageMapping("/connect/room")
+    public void connect(@Payload ConnectIncomingMessageDTO incoming, @Header("simpSessionId") String sessionId) {
+        connectService.connect(incoming);
+    }
 }


### PR DESCRIPTION
This is part of [TRIB-148: Increase coverage to 50%](https://mockprogrammingjob.atlassian.net/browse/TRIB-148?atlOrigin=eyJpIjoiNjNlMDg3OGU3NTQ0NDkzZWIwNTAxMjBjYmM1YTdhNTUiLCJwIjoiaiJ9).
There are certain services that contain faulty logic. For unit tests to pass, they need to be fixed. These are the changes this PR makes:

- Ensure notification sent by AttributesAPIController matches the phrase's approval status (currently, it does the reverse of what the approval status would indicate).
- Add Spring's @RequestBody annotation in ConnectAPIController's connect method, so request body isn't null when a POST request is sent to /api/connect.