### PR TITLE
Trib 222: bug fix for AttributesAPIController

### DIFF
--- a/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
@@ -94,16 +94,17 @@ public class AttributesAPIController {
   private void sendNotification(Boolean approved, Long userId) {
     if (approved) {
       notificationService.createNotification(
-          NotificationType.ATTRIBUTE_REQUEST_REJECTED,
-          userId,
-          NotificationType.ATTRIBUTE_REQUEST_REJECTED.getName(),
-          "Your attribute was rejected. This attribute is unsuitable and cannot be applied to users.");
-    } else {
-      notificationService.createNotification(
           NotificationType.ATTRIBUTE_REQUEST_APPROVED,
           userId,
           NotificationType.ATTRIBUTE_REQUEST_APPROVED.getName(),
           "Your attribute has been approved!");
+
+    } else {
+      notificationService.createNotification(
+          NotificationType.ATTRIBUTE_REQUEST_REJECTED,
+          userId,
+          NotificationType.ATTRIBUTE_REQUEST_REJECTED.getName(),
+          "Your attribute was rejected. This attribute is unsuitable and cannot be applied to users.");
     }
   }
 }

--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -42,7 +42,7 @@ public class ConnectAPIController {
 
   @Connect
   @PostMapping
-  public boolean connect(@Valid ConnectRequest connectRequest) {
+  public boolean connect(@RequestBody @Valid ConnectRequest connectRequest) {
     if (connectService.validateQRCode(
         connectRequest.qrcodePhrase, connectRequest.toBeConnectedWithUserId)) {
       boolean isConnectionSaved =

--- a/src/main/java/com/savvato/tribeapp/entities/NotificationType.java
+++ b/src/main/java/com/savvato/tribeapp/entities/NotificationType.java
@@ -7,7 +7,7 @@ import javax.persistence.*;
 public class NotificationType {
 
     public static final NotificationType ATTRIBUTE_REQUEST_APPROVED = new NotificationType(1L, "Attribute request approved", null);
-    public static final NotificationType ATTRIBUTE_REQUEST_REJECTED = new NotificationType(1L, "Attribute request approved", null);
+    public static final NotificationType ATTRIBUTE_REQUEST_REJECTED = new NotificationType(1L, "Attribute request rejected", null);
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/com/savvato/tribeapp/controllers/AttributesAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/AttributesAPITest.java
@@ -70,6 +70,12 @@ public class AttributesAPITest {
     @MockBean
     private NotificationService notificationService;
 
+    @MockBean
+    private UserPhraseService userPhraseService;
+
+    @MockBean
+    private ReviewSubmittingUserService reviewSubmittingUserService;
+
     @BeforeEach
     public void setUp() throws Exception {
         mockMvc =

--- a/src/test/java/com/savvato/tribeapp/controllers/AttributesAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/AttributesAPITest.java
@@ -35,8 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AttributesAPIController.class)
@@ -308,4 +307,29 @@ public class AttributesAPITest {
                 NotificationType.ATTRIBUTE_REQUEST_REJECTED.getName());
         assertEquals(notificationContentCaptor.getValue(), notificationContent);
     }
+
+    @Test
+    public void deletePhraseFromUserHappyPath() throws Exception {
+        String phraseId = "1";
+        String userId = "1";
+        Mockito.when(userPrincipalService.getUserPrincipalByEmail(Mockito.anyString()))
+                .thenReturn(new UserPrincipal(user));
+        String auth = AuthServiceImpl.generateAccessToken(user);
+
+        doNothing().when(userPhraseService).deletePhraseFromUser(anyLong(),anyLong());
+
+        this.mockMvc
+                .perform(
+                        delete("/api/attributes")
+                                .header("Authorization", "Bearer " + auth)
+                                .characterEncoding("utf-8")
+                                .param("phraseId", phraseId)
+                                .param("userId", userId))
+
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(userPhraseService, times(1)).deletePhraseFromUser(Long.parseLong(phraseId), Long.parseLong(userId));
+    }
+    
 }

--- a/src/test/java/com/savvato/tribeapp/controllers/AttributesAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/AttributesAPITest.java
@@ -26,10 +26,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.lang.reflect.Type;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -366,6 +363,32 @@ public class AttributesAPITest {
         List<ToBeReviewedDTO> actualAttributes =
                 gson.fromJson(result.getResponse().getContentAsString(), toBeReviewedDTOListType);
         assertThat(actualAttributes).usingRecursiveComparison().isEqualTo(expectedToBeReviewed);
+    }
+
+    @Test
+    public void getUserPhrasesToBeReviewedHappyPathNoPhrases() throws Exception {
+        Mockito.when(userPrincipalService.getUserPrincipalByEmail(Mockito.anyString()))
+                .thenReturn(new UserPrincipal(user));
+        String auth = AuthServiceImpl.generateAccessToken(user);
+        Long userId = 1L;
+
+        when(reviewSubmittingUserService.getUserPhrasesToBeReviewed(anyLong())).thenReturn(new ArrayList<>());
+
+        MvcResult result =
+                this.mockMvc
+                        .perform(
+                                get("/api/attributes/in-review/{userId}", userId)
+                                        .header("Authorization", "Bearer " + auth)
+                                        .characterEncoding("utf-8"))
+                        .andExpect(status().isOk())
+                        .andReturn();
+
+        Type toBeReviewedDTOListType = new TypeToken<List<ToBeReviewedDTO>>() {
+        }.getType();
+
+        List<ToBeReviewedDTO> actualAttributes =
+                gson.fromJson(result.getResponse().getContentAsString(), toBeReviewedDTOListType);
+        assertThat(actualAttributes).isEmpty();
     }
 
 }


### PR DESCRIPTION
- adds missing mock beans
- corrects true/false logic for the sendNotification() method in the API Controller
- corrects name of rejected request in Notification types
- also adds missing "@RequestBody" to Connect Controller

Testing
- runs and compiles
- tests run successfully without errors
- program runs in browser