### PR TITLE
TRIB-174: Add endpoint that calculates number of users with a given attribute

### DIFF
--- a/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
@@ -3,6 +3,7 @@ package com.savvato.tribeapp.controllers;
 import com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPIController.*;
 import com.savvato.tribeapp.controllers.dto.AttributesRequest;
 import com.savvato.tribeapp.dto.AttributeDTO;
+import com.savvato.tribeapp.dto.GenericMessageDTO;
 import com.savvato.tribeapp.dto.ToBeReviewedDTO;
 import com.savvato.tribeapp.entities.NotificationType;
 import com.savvato.tribeapp.services.*;
@@ -44,11 +45,15 @@ public class AttributesAPIController {
 
     @GetNumberOfUsersWithAttribute
     @GetMapping("/total/{attributeId}")
-    public ResponseEntity<Integer> getNumberOfUsersWithAttribute(
+    public ResponseEntity<GenericMessageDTO> getNumberOfUsersWithAttribute(
             @Parameter(description = "Attribute ID", example = "1") @PathVariable Long attributeId) {
 
         Optional<Integer> numberOfUsers = attributesService.getNumberOfUsersWithAttribute(attributeId);
-        if (numberOfUsers.isPresent()) return ResponseEntity.ok(numberOfUsers.get());
+
+        if (numberOfUsers.isPresent()) {
+            String userCount = String.valueOf(numberOfUsers.get());
+            return ResponseEntity.ok(GenericMessageDTO.builder().responseMessage(userCount).build());
+        }
         return ResponseEntity.badRequest().build();
     }
 

--- a/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
@@ -1,9 +1,6 @@
 package com.savvato.tribeapp.controllers;
 
-import com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPIController.ApplyPhraseToUser;
-import com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPIController.DeletePhraseFromUser;
-import com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPIController.GetAttributesForUser;
-import com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPIController.GetUserPhrasesToBeReviewed;
+import com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPIController.*;
 import com.savvato.tribeapp.controllers.dto.AttributesRequest;
 import com.savvato.tribeapp.dto.AttributeDTO;
 import com.savvato.tribeapp.dto.ToBeReviewedDTO;
@@ -11,100 +8,112 @@ import com.savvato.tribeapp.entities.NotificationType;
 import com.savvato.tribeapp.services.*;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
-import java.util.Optional;
-import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+import java.util.List;
+import java.util.Optional;
+
 @RestController
 @RequestMapping("/api/attributes")
 @Tag(
-    name = "attributes",
-    description = "Everything about attributes, e.g. \"plays chess competitively\"")
+        name = "attributes",
+        description = "Everything about attributes, e.g. \"plays chess competitively\"")
 public class AttributesAPIController {
 
-  @Autowired 
-  AttributesService attributesService;
+    @Autowired
+    AttributesService attributesService;
 
-  @Autowired
-  PhraseService phraseService;
+    @Autowired
+    PhraseService phraseService;
 
-  @Autowired 
-  NotificationService notificationService;
+    @Autowired
+    NotificationService notificationService;
 
-  @Autowired
-  UserPhraseService userPhraseService;
+    @Autowired
+    UserPhraseService userPhraseService;
 
-  @Autowired
-  ReviewSubmittingUserService reviewSubmittingUserService;
+    @Autowired
+    ReviewSubmittingUserService reviewSubmittingUserService;
 
-  AttributesAPIController() {}
-
-  @GetAttributesForUser
-  @GetMapping("/{userId}")
-  public ResponseEntity<List<AttributeDTO>> getAttributesForUser(
-      @Parameter(description = "User ID of user", example = "1") @PathVariable Long userId) {
-
-    Optional<List<AttributeDTO>> opt = attributesService.getAttributesByUserId(userId);
-
-    if (opt.isPresent()) return ResponseEntity.status(HttpStatus.OK).body(opt.get());
-    else return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
-  }
-
-  @GetUserPhrasesToBeReviewed
-  @GetMapping("/in-review/{userId}")
-  public ResponseEntity<List<ToBeReviewedDTO>> getUserPhrasesToBeReviewed(
-          @Parameter(description = "User ID of user", example = "1")
-          @PathVariable Long userId) {
-    List<ToBeReviewedDTO> rtn = reviewSubmittingUserService.getUserPhrasesToBeReviewed(userId);
-      return ResponseEntity.status(HttpStatus.OK).body(rtn);
+    AttributesAPIController() {
     }
 
-  @ApplyPhraseToUser
-  @PostMapping
-  public ResponseEntity<Boolean> applyPhraseToUser(@RequestBody @Valid AttributesRequest req) {
-    if (phraseService.isPhraseValid(req.adverb, req.verb, req.preposition, req.noun)) {
-      boolean isPhraseApplied =
-          phraseService.applyPhraseToUser(
-              req.userId, req.adverb, req.verb, req.preposition, req.noun);
-      if (isPhraseApplied) {
-        sendNotification(true, req.userId);
-        return ResponseEntity.status(HttpStatus.OK).body(true);
-      } else {
-        sendNotification(false, req.userId);
-        return ResponseEntity.status(HttpStatus.OK).body(false);
-      }
-    } else {
-      sendNotification(false, req.userId);
-      return ResponseEntity.status(HttpStatus.OK).body(false);
+    @GetNumberOfUsersWithAttribute
+    @GetMapping("/total/{attributeId}")
+    public ResponseEntity<Integer> getNumberOfUsersWithAttribute(
+            @Parameter(description = "Attribute ID", example = "1") @PathVariable Long attributeId) {
+
+        Optional<Integer> numberOfUsers = attributesService.getNumberOfUsersWithAttribute(attributeId);
+        if (numberOfUsers.isPresent()) return ResponseEntity.ok(numberOfUsers.get());
+        return ResponseEntity.badRequest().build();
     }
-  }
 
-  ///api/attributes/?phraseId=xx&userId=xx
-  @DeletePhraseFromUser
-  @DeleteMapping
-  public ResponseEntity deletePhraseFromUser(@Parameter(description = "Phrase ID of phrase", example = "1") @RequestParam("phraseId") Long phraseId, @Parameter(description = "User ID of user", example = "1") @RequestParam("userId") Long userId) {
-      userPhraseService.deletePhraseFromUser(phraseId, userId);
-      return ResponseEntity.ok().build();
-  }
+    @GetAttributesForUser
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<AttributeDTO>> getAttributesForUser(
+            @Parameter(description = "User ID of user", example = "1") @PathVariable Long userId) {
 
-  private void sendNotification(Boolean approved, Long userId) {
-    if (approved) {
-      notificationService.createNotification(
-          NotificationType.ATTRIBUTE_REQUEST_APPROVED,
-          userId,
-          NotificationType.ATTRIBUTE_REQUEST_APPROVED.getName(),
-          "Your attribute has been approved!");
+        Optional<List<AttributeDTO>> opt = attributesService.getAttributesByUserId(userId);
 
-    } else {
-      notificationService.createNotification(
-          NotificationType.ATTRIBUTE_REQUEST_REJECTED,
-          userId,
-          NotificationType.ATTRIBUTE_REQUEST_REJECTED.getName(),
-          "Your attribute was rejected. This attribute is unsuitable and cannot be applied to users.");
+        if (opt.isPresent()) return ResponseEntity.status(HttpStatus.OK).body(opt.get());
+        else return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
     }
-  }
+
+    @GetUserPhrasesToBeReviewed
+    @GetMapping("/in-review/{userId}")
+    public ResponseEntity<List<ToBeReviewedDTO>> getUserPhrasesToBeReviewed(
+            @Parameter(description = "User ID of user", example = "1")
+            @PathVariable Long userId) {
+        List<ToBeReviewedDTO> rtn = reviewSubmittingUserService.getUserPhrasesToBeReviewed(userId);
+        return ResponseEntity.status(HttpStatus.OK).body(rtn);
+    }
+
+    @ApplyPhraseToUser
+    @PostMapping
+    public ResponseEntity<Boolean> applyPhraseToUser(@RequestBody @Valid AttributesRequest req) {
+        if (phraseService.isPhraseValid(req.adverb, req.verb, req.preposition, req.noun)) {
+            boolean isPhraseApplied =
+                    phraseService.applyPhraseToUser(
+                            req.userId, req.adverb, req.verb, req.preposition, req.noun);
+            if (isPhraseApplied) {
+                sendNotification(true, req.userId);
+                return ResponseEntity.status(HttpStatus.OK).body(true);
+            } else {
+                sendNotification(false, req.userId);
+                return ResponseEntity.status(HttpStatus.OK).body(false);
+            }
+        } else {
+            sendNotification(false, req.userId);
+            return ResponseEntity.status(HttpStatus.OK).body(false);
+        }
+    }
+
+    ///api/attributes/?phraseId=xx&userId=xx
+    @DeletePhraseFromUser
+    @DeleteMapping
+    public ResponseEntity deletePhraseFromUser(@Parameter(description = "Phrase ID of phrase", example = "1") @RequestParam("phraseId") Long phraseId, @Parameter(description = "User ID of user", example = "1") @RequestParam("userId") Long userId) {
+        userPhraseService.deletePhraseFromUser(phraseId, userId);
+        return ResponseEntity.ok().build();
+    }
+
+    private void sendNotification(Boolean approved, Long userId) {
+        if (approved) {
+            notificationService.createNotification(
+                    NotificationType.ATTRIBUTE_REQUEST_APPROVED,
+                    userId,
+                    NotificationType.ATTRIBUTE_REQUEST_APPROVED.getName(),
+                    "Your attribute has been approved!");
+
+        } else {
+            notificationService.createNotification(
+                    NotificationType.ATTRIBUTE_REQUEST_REJECTED,
+                    userId,
+                    NotificationType.ATTRIBUTE_REQUEST_REJECTED.getName(),
+                    "Your attribute was rejected. This attribute is unsuitable and cannot be applied to users.");
+        }
+    }
 }

--- a/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/AttributesAPIController/GetNumberOfUsersWithAttribute.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/AttributesAPIController/GetNumberOfUsersWithAttribute.java
@@ -1,0 +1,23 @@
+package com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPIController;
+
+import com.savvato.tribeapp.controllers.annotations.responses.BadRequest;
+import com.savvato.tribeapp.controllers.annotations.responses.Success;
+import io.swagger.v3.oas.annotations.Operation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "Get number of users with an attribute.",
+        description = "Provided an attribute ID, get the number of users that share this attribute.")
+@Success(
+        description = "Successfully retrieved user attributes",
+        implementation = Integer.class,
+        example = "8")
+@BadRequest(
+        description = "Failed to retrieve number of users with this attribute",
+        noContent = true)
+public @interface GetNumberOfUsersWithAttribute {
+}

--- a/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/AttributesAPIController/GetNumberOfUsersWithAttribute.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/AttributesAPIController/GetNumberOfUsersWithAttribute.java
@@ -2,6 +2,7 @@ package com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPICo
 
 import com.savvato.tribeapp.controllers.annotations.responses.BadRequest;
 import com.savvato.tribeapp.controllers.annotations.responses.Success;
+import com.savvato.tribeapp.dto.GenericMessageDTO;
 import io.swagger.v3.oas.annotations.Operation;
 
 import java.lang.annotation.*;
@@ -14,8 +15,7 @@ import java.lang.annotation.*;
         description = "Provided an attribute ID, get the number of users that share this attribute.")
 @Success(
         description = "Successfully retrieved user attributes",
-        implementation = Integer.class,
-        example = "8")
+        implementation = GenericMessageDTO.class)
 @BadRequest(
         description = "Failed to retrieve number of users with this attribute",
         noContent = true)

--- a/src/main/java/com/savvato/tribeapp/repositories/UserPhraseRepository.java
+++ b/src/main/java/com/savvato/tribeapp/repositories/UserPhraseRepository.java
@@ -14,4 +14,6 @@ public interface UserPhraseRepository extends CrudRepository<UserPhrase, UserPhr
     @Query(nativeQuery = true, value = "select phrase_id from user_phrase where user_id = ?")
     Optional<List<Long>> findPhraseIdsByUserId(Long Id);
 
+    @Query(nativeQuery = true, value = "select COUNT(*) FROM user_phrase where attribute_id = ?")
+    Integer countUsersWithAttribute(Long attributeId);
 }

--- a/src/main/java/com/savvato/tribeapp/services/AttributesService.java
+++ b/src/main/java/com/savvato/tribeapp/services/AttributesService.java
@@ -9,5 +9,6 @@ public interface AttributesService {
 
     Optional<List<AttributeDTO>> getAttributesByUserId(Long id);
 
+    Optional<Integer> getNumberOfUsersWithAttribute(Long attributeId);
 }
 

--- a/src/main/java/com/savvato/tribeapp/services/AttributesServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/AttributesServiceImpl.java
@@ -2,6 +2,7 @@ package com.savvato.tribeapp.services;
 
 import com.savvato.tribeapp.dto.AttributeDTO;
 import com.savvato.tribeapp.dto.PhraseDTO;
+import com.savvato.tribeapp.repositories.UserPhraseRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -10,10 +11,13 @@ import java.util.List;
 import java.util.Optional;
 
 @Service
-public class AttributesServiceImpl implements AttributesService{
+public class AttributesServiceImpl implements AttributesService {
 
     @Autowired
     PhraseService phraseService;
+
+    @Autowired
+    UserPhraseRepository userPhraseRepository;
 
     @Override
     public Optional<List<AttributeDTO>> getAttributesByUserId(Long userId) {
@@ -24,9 +28,9 @@ public class AttributesServiceImpl implements AttributesService{
         Optional<List<PhraseDTO>> optUserPhraseDTOs = phraseService.getListOfPhraseDTOByUserIdWithoutPlaceholderNullvalue(userId);
 
         // If there are phrases, build DTO and add to attributes list
-        if(optUserPhraseDTOs.isPresent()) {
+        if (optUserPhraseDTOs.isPresent()) {
             List<PhraseDTO> phrases = optUserPhraseDTOs.get();
-            for(PhraseDTO phrase : phrases) {
+            for (PhraseDTO phrase : phrases) {
                 AttributeDTO attributeDTO = AttributeDTO.builder()
                         .phrase(phrase)
                         .build();
@@ -36,5 +40,15 @@ public class AttributesServiceImpl implements AttributesService{
 
         // Returns list of attributeDTOs. Can be empty.
         return Optional.of(attributes);
+    }
+
+    @Override
+    public Optional<Integer> getNumberOfUsersWithAttribute(Long attributeId) {
+        try {
+            Integer numberOfUsers = userPhraseRepository.countUsersWithAttribute(attributeId);
+            return Optional.of(numberOfUsers);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
     }
 }

--- a/src/test/java/com/savvato/tribeapp/services/AttributesServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/AttributesServiceImplTest.java
@@ -2,6 +2,7 @@ package com.savvato.tribeapp.services;
 
 import com.savvato.tribeapp.dto.AttributeDTO;
 import com.savvato.tribeapp.dto.PhraseDTO;
+import com.savvato.tribeapp.repositories.UserPhraseRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -35,6 +36,8 @@ public class AttributesServiceImplTest {
     AttributesService attributesService;
     @MockBean
     PhraseService phraseService;
+    @MockBean
+    UserPhraseRepository userPhraseRepository;
 
     @Test
     public void getAttributesByUserIdWhenAttributesExist() {
@@ -74,5 +77,33 @@ public class AttributesServiceImplTest {
         verify(phraseService, times(1)).getListOfPhraseDTOByUserIdWithoutPlaceholderNullvalue(userIdArgumentCaptor.capture());
         assertEquals(userIdArgumentCaptor.getValue(), userId);
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void getNumberOfUsersWithAttributeWhenAttributeExists() {
+        Long attributeId = 1L;
+        Integer userCount = 2;
+        Optional<Integer> expected = Optional.of(userCount);
+        ArgumentCaptor<Long> attributeIdCaptor = ArgumentCaptor.forClass(Long.class);
+        when(userPhraseRepository.countUsersWithAttribute(anyLong())).thenReturn(userCount);
+        Optional<Integer> actual = attributesService.getNumberOfUsersWithAttribute(attributeId);
+        verify(userPhraseRepository, times(1)).countUsersWithAttribute(attributeIdCaptor.capture());
+        assertEquals(attributeIdCaptor.getValue(), attributeId);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void getNumberOfUsersWithAttributeWhenErrorOccurs() {
+        Long attributeId = 1L;
+        String errorMessage = "An error occurred";
+        Optional<Integer> expected = Optional.empty();
+        ArgumentCaptor<Long> attributeIdCaptor = ArgumentCaptor.forClass(Long.class);
+        when(userPhraseRepository.countUsersWithAttribute(anyLong())).thenThrow(new IllegalArgumentException(errorMessage));
+        Optional<Integer> actual = attributesService.getNumberOfUsersWithAttribute(attributeId);
+
+        verify(userPhraseRepository, times(1)).countUsersWithAttribute(attributeIdCaptor.capture());
+        assertEquals(attributeIdCaptor.getValue(), attributeId);
+        assertThat(actual).isEqualTo(expected);
+
     }
 }


### PR DESCRIPTION
Per TRIB-174, we need an endpoint that takes an attribute ID and calculates the number of users that are using that attribute. This PR makes the following changes to put the endpoint into place:

- Add query method to userPhraseRepository that counts the number of users that share the attribute ID
- Add AttributesService method that invokes above method, returning an Optional with the information (or an empty Optional if the database query fails)
- Add GET endpoint at /api/attributes/total/{attributeId} that returns the number of users with a 200 status, or a 400 status depending on the Optional returned by attribtuesService
- Create Swagger annotation for above endpoint to document it