### PR TITLE
TRIB-105: Create endpoint for removing connection

### DIFF
--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -1,15 +1,13 @@
 package com.savvato.tribeapp.controllers;
 
-import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController.Connect;
 import com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController.GetQRCodeString;
 import com.savvato.tribeapp.controllers.dto.ConnectRequest;
+import com.savvato.tribeapp.controllers.dto.ConnectionDeleteRequest;
 import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
 import com.savvato.tribeapp.services.ConnectService;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.Optional;
-import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,48 +16,57 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+import java.util.Optional;
+
 @RestController
 @Tag(name = "connect", description = "Connections between users")
 @RequestMapping("/api/connect")
 public class ConnectAPIController {
-  @Autowired ConnectService connectService;
+    @Autowired
+    ConnectService connectService;
 
-  ConnectAPIController() {}
-
-  @GetQRCodeString
-  @GetMapping("/{userId}")
-  public ResponseEntity getQrCodeString(
-      @Parameter(description = "The user ID of a user", example = "1") @PathVariable Long userId) {
-
-    Optional<String> opt = connectService.storeQRCodeString(userId);
-
-    if (opt.isPresent()) {
-      return ResponseEntity.status(HttpStatus.OK).body(opt.get());
-    } else {
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+    ConnectAPIController() {
     }
-  }
 
-  @Connect
-  @PostMapping
-  public boolean connect(@RequestBody @Valid ConnectRequest connectRequest) {
-    if (connectService.validateQRCode(
-        connectRequest.qrcodePhrase, connectRequest.toBeConnectedWithUserId)) {
-      boolean isConnectionSaved =
-          connectService.saveConnectionDetails(
-              connectRequest.requestingUserId, connectRequest.toBeConnectedWithUserId);
-      if (isConnectionSaved) {
-        return true;
-      } else {
-        return false;
-      }
-    } else {
-      return false;
+    @GetQRCodeString
+    @GetMapping("/{userId}")
+    public ResponseEntity getQrCodeString(
+            @Parameter(description = "The user ID of a user", example = "1") @PathVariable Long userId) {
+
+        Optional<String> opt = connectService.storeQRCodeString(userId);
+
+        if (opt.isPresent()) {
+            return ResponseEntity.status(HttpStatus.OK).body(opt.get());
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        }
     }
-  }
 
-  @MessageMapping("/connect/room")
-  public void connect(@Payload ConnectIncomingMessageDTO incoming, @Header("simpSessionId") String sessionId) {
-      connectService.connect(incoming);
-  }
+    @Connect
+    @PostMapping
+    public boolean connect(@RequestBody @Valid ConnectRequest connectRequest) {
+        if (connectService.validateQRCode(
+                connectRequest.qrcodePhrase, connectRequest.toBeConnectedWithUserId)) {
+            boolean isConnectionSaved =
+                    connectService.saveConnectionDetails(
+                            connectRequest.requestingUserId, connectRequest.toBeConnectedWithUserId);
+            return isConnectionSaved;
+        } else {
+            return false;
+        }
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Boolean> removeConnection(@RequestBody @Valid ConnectionDeleteRequest connectionDeleteRequest) {
+        if (connectService.removeConnection(connectionDeleteRequest)) {
+            return ResponseEntity.ok().body(true);
+        }
+        return ResponseEntity.badRequest().body(false);
+    }
+
+    @MessageMapping("/connect/room")
+    public void connect(@Payload ConnectIncomingMessageDTO incoming, @Header("simpSessionId") String sessionId) {
+        connectService.connect(incoming);
+    }
 }

--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -58,8 +58,8 @@ public class ConnectAPIController {
     }
 
     @DeleteMapping
-    public ResponseEntity<Boolean> removeConnection(@RequestBody @Valid ConnectionRemovalRequest connectionDeleteRequest) {
-        if (connectService.removeConnection(connectionDeleteRequest)) {
+    public ResponseEntity<Boolean> removeConnection(@RequestBody @Valid ConnectionRemovalRequest connectionRemovalRequest) {
+        if (connectService.removeConnection(connectionRemovalRequest)) {
             return ResponseEntity.ok().body(true);
         }
         return ResponseEntity.badRequest().body(false);

--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -3,7 +3,7 @@ package com.savvato.tribeapp.controllers;
 import com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController.Connect;
 import com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController.GetQRCodeString;
 import com.savvato.tribeapp.controllers.dto.ConnectRequest;
-import com.savvato.tribeapp.controllers.dto.ConnectionDeleteRequest;
+import com.savvato.tribeapp.controllers.dto.ConnectionRemovalRequest;
 import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
 import com.savvato.tribeapp.services.ConnectService;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -58,7 +58,7 @@ public class ConnectAPIController {
     }
 
     @DeleteMapping
-    public ResponseEntity<Boolean> removeConnection(@RequestBody @Valid ConnectionDeleteRequest connectionDeleteRequest) {
+    public ResponseEntity<Boolean> removeConnection(@RequestBody @Valid ConnectionRemovalRequest connectionDeleteRequest) {
         if (connectService.removeConnection(connectionDeleteRequest)) {
             return ResponseEntity.ok().body(true);
         }

--- a/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/ConnectAPIController/RemoveConnection.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/ConnectAPIController/RemoveConnection.java
@@ -1,0 +1,28 @@
+package com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController;
+
+
+import com.savvato.tribeapp.controllers.annotations.requests.DocumentedRequestBody;
+import com.savvato.tribeapp.controllers.annotations.responses.BadRequest;
+import com.savvato.tribeapp.controllers.annotations.responses.Success;
+import com.savvato.tribeapp.controllers.dto.ConnectionRemovalRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "Delete connection between two users",
+        description = "Provided a ConnectionRemovalRequest (see schemas), save the connection.")
+@DocumentedRequestBody(description = "A request to delete connection", implementation = ConnectionRemovalRequest.class)
+@Success(
+        description = "Status of attempt to delete connection",
+        examples = {
+                @ExampleObject(name = "Connection deleted successfully", value = "true"),
+                @ExampleObject(name = "Connection could not be deleted", value = "false"),
+        })
+@BadRequest(description = "Could not delete the connection", noContent = true)
+public @interface RemoveConnection {
+}

--- a/src/main/java/com/savvato/tribeapp/controllers/dto/ConnectionDeleteRequest.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/dto/ConnectionDeleteRequest.java
@@ -1,0 +1,12 @@
+package com.savvato.tribeapp.controllers.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "A request to delete a connection between two users")
+public class ConnectionDeleteRequest {
+    @Schema(example = "1")
+    public Long requestingUserId;
+
+    @Schema(example = "2")
+    public Long connectedWithUserId;
+}

--- a/src/main/java/com/savvato/tribeapp/controllers/dto/ConnectionRemovalRequest.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/dto/ConnectionRemovalRequest.java
@@ -3,7 +3,7 @@ package com.savvato.tribeapp.controllers.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "A request to delete a connection between two users")
-public class ConnectionDeleteRequest {
+public class ConnectionRemovalRequest {
     @Schema(example = "1")
     public Long requestingUserId;
 

--- a/src/main/java/com/savvato/tribeapp/repositories/ConnectionsRepository.java
+++ b/src/main/java/com/savvato/tribeapp/repositories/ConnectionsRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ConnectionsRepository extends CrudRepository<Connection, Long> {
-    @Query(nativeQuery = true, value = "delete from connections where requested_user_id=?1 AND to_be_connected_with_user_id=?2")
+    @Query(nativeQuery = true, value = "delete from connections where requesting_user_id=?1 AND to_be_connected_with_user_id=?2")
     void removeConnection(Long requestingUserId, Long connectedWithUserId);
 }

--- a/src/main/java/com/savvato/tribeapp/repositories/ConnectionsRepository.java
+++ b/src/main/java/com/savvato/tribeapp/repositories/ConnectionsRepository.java
@@ -1,10 +1,12 @@
 package com.savvato.tribeapp.repositories;
 
 import com.savvato.tribeapp.entities.Connection;
-import com.savvato.tribeapp.entities.Noun;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ConnectionsRepository extends CrudRepository<Connection, Long> {
+    @Query(nativeQuery = true, value = "delete from connections where requested_user_id=?1 AND to_be_connected_with_user_id=?2")
+    void removeConnection(Long requestingUserId, Long connectedWithUserId);
 }

--- a/src/main/java/com/savvato/tribeapp/services/ConnectService.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectService.java
@@ -1,6 +1,6 @@
 package com.savvato.tribeapp.services;
 
-import com.savvato.tribeapp.controllers.dto.ConnectionDeleteRequest;
+import com.savvato.tribeapp.controllers.dto.ConnectionRemovalRequest;
 import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
 import com.savvato.tribeapp.dto.ConnectOutgoingMessageDTO;
 
@@ -20,5 +20,5 @@ public interface ConnectService {
 
     ConnectOutgoingMessageDTO handleConnectionIntent(String connectionIntent, Long requestingUserId, Long toBeRequestedWithUserId);
 
-    boolean removeConnection(ConnectionDeleteRequest connectionDeleteRequest);
+    boolean removeConnection(ConnectionRemovalRequest connectionDeleteRequest);
 }

--- a/src/main/java/com/savvato/tribeapp/services/ConnectService.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectService.java
@@ -1,9 +1,8 @@
 package com.savvato.tribeapp.services;
 
-import com.savvato.tribeapp.config.principal.UserPrincipal;
+import com.savvato.tribeapp.controllers.dto.ConnectionDeleteRequest;
 import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
 import com.savvato.tribeapp.dto.ConnectOutgoingMessageDTO;
-import org.springframework.messaging.handler.annotation.Header;
 
 import java.util.Optional;
 
@@ -14,8 +13,12 @@ public interface ConnectService {
     Optional<String> storeQRCodeString(long userId);
 
     Boolean validateQRCode(String qrcodePhrase, Long toBeConnectedWithUserId);
+
     void connect(ConnectIncomingMessageDTO incoming);
 
     boolean saveConnectionDetails(Long requestingUserId, Long toBeConnectedWithUserId);
+
     ConnectOutgoingMessageDTO handleConnectionIntent(String connectionIntent, Long requestingUserId, Long toBeRequestedWithUserId);
+
+    boolean removeConnection(ConnectionDeleteRequest connectionDeleteRequest);
 }

--- a/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
@@ -126,12 +126,12 @@ public class ConnectServiceImpl implements ConnectService {
         return null;
     }
 
-    public boolean removeConnection(ConnectionRemovalRequest connectionDeleteRequest) {
-        if (Objects.equals(connectionDeleteRequest.requestingUserId, connectionDeleteRequest.connectedWithUserId)) {
+    public boolean removeConnection(ConnectionRemovalRequest connectionRemovalRequest) {
+        if (Objects.equals(connectionRemovalRequest.requestingUserId, connectionRemovalRequest.connectedWithUserId)) {
             return false;
         }
         try {
-            connectionsRepository.removeConnection(connectionDeleteRequest.requestingUserId, connectionDeleteRequest.connectedWithUserId);
+            connectionsRepository.removeConnection(connectionRemovalRequest.requestingUserId, connectionRemovalRequest.connectedWithUserId);
             return true;
         } catch (Exception e) {
             return false;

--- a/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
@@ -1,7 +1,6 @@
 package com.savvato.tribeapp.services;
 
-import com.savvato.tribeapp.config.principal.UserPrincipal;
-import com.savvato.tribeapp.controllers.dto.ConnectRequest;
+import com.savvato.tribeapp.controllers.dto.ConnectionDeleteRequest;
 import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
 import com.savvato.tribeapp.dto.ConnectOutgoingMessageDTO;
 import com.savvato.tribeapp.entities.Connection;
@@ -10,9 +9,7 @@ import com.savvato.tribeapp.repositories.UserRepository;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
@@ -37,7 +34,7 @@ public class ConnectServiceImpl implements ConnectService {
 
     private final int QRCODE_STRING_LENGTH = 12;
 
-    public Optional<String> getQRCodeString(long userId){
+    public Optional<String> getQRCodeString(long userId) {
         String userIdToCacheKey = String.valueOf(userId);
         String getCode = cache.get("ConnectQRCodeString", userIdToCacheKey);
         Optional<String> opt = Optional.of(getCode);
@@ -45,7 +42,7 @@ public class ConnectServiceImpl implements ConnectService {
 
     }
 
-    public Optional<String> storeQRCodeString(long userId){
+    public Optional<String> storeQRCodeString(long userId) {
         String generatedQRCodeString = generateRandomString(QRCODE_STRING_LENGTH);
         String userIdToCacheKey = String.valueOf(userId);
         cache.put("ConnectQRCodeString", userIdToCacheKey, generatedQRCodeString);
@@ -53,7 +50,7 @@ public class ConnectServiceImpl implements ConnectService {
         return Optional.of(generatedQRCodeString);
     }
 
-    private String generateRandomString(int length){
+    private String generateRandomString(int length) {
         Random random = new Random();
         char[] digits = new char[length];
         digits[0] = (char) (random.nextInt(9) + '1');
@@ -80,11 +77,11 @@ public class ConnectServiceImpl implements ConnectService {
 
     @MessageMapping("/connect/room")
     public void connect(ConnectIncomingMessageDTO incoming) {
-        if(!validateQRCode(incoming.qrcodePhrase, incoming.toBeConnectedWithUserId)) {
+        if (!validateQRCode(incoming.qrcodePhrase, incoming.toBeConnectedWithUserId)) {
             ConnectOutgoingMessageDTO msg = ConnectOutgoingMessageDTO.builder()
-                                            .connectionError(true)
-                                            .message("Invalid QR code; failed to connect.")
-                                            .build();
+                    .connectionError(true)
+                    .message("Invalid QR code; failed to connect.")
+                    .build();
             simpMessagingTemplate.convertAndSendToUser(
                     String.valueOf(incoming.toBeConnectedWithUserId),
                     "/connect/user/queue/specific-user",
@@ -102,7 +99,7 @@ public class ConnectServiceImpl implements ConnectService {
 
     public ConnectOutgoingMessageDTO handleConnectionIntent(String connectionIntent, Long requestingUserId, Long toBeConnectedWithUserId) {
         if (connectionIntent == "") {
-            List<Long> recipients = new ArrayList<>(Arrays.asList(toBeConnectedWithUserId));
+            List<Long> recipients = new ArrayList<>(Collections.singletonList(toBeConnectedWithUserId));
             return ConnectOutgoingMessageDTO.builder().message("Please confirm that you wish to connect.").to(recipients).build();
         } else if (connectionIntent == "confirmed") {
             Boolean connectionStatus = saveConnectionDetails(requestingUserId, toBeConnectedWithUserId);
@@ -127,5 +124,17 @@ public class ConnectServiceImpl implements ConnectService {
 
         }
         return null;
+    }
+
+    public boolean removeConnection(ConnectionDeleteRequest connectionDeleteRequest) {
+        if (Objects.equals(connectionDeleteRequest.requestingUserId, connectionDeleteRequest.connectedWithUserId)) {
+            return false;
+        }
+        try {
+            connectionsRepository.removeConnection(connectionDeleteRequest.requestingUserId, connectionDeleteRequest.connectedWithUserId);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
@@ -1,6 +1,6 @@
 package com.savvato.tribeapp.services;
 
-import com.savvato.tribeapp.controllers.dto.ConnectionDeleteRequest;
+import com.savvato.tribeapp.controllers.dto.ConnectionRemovalRequest;
 import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
 import com.savvato.tribeapp.dto.ConnectOutgoingMessageDTO;
 import com.savvato.tribeapp.entities.Connection;
@@ -126,7 +126,7 @@ public class ConnectServiceImpl implements ConnectService {
         return null;
     }
 
-    public boolean removeConnection(ConnectionDeleteRequest connectionDeleteRequest) {
+    public boolean removeConnection(ConnectionRemovalRequest connectionDeleteRequest) {
         if (Objects.equals(connectionDeleteRequest.requestingUserId, connectionDeleteRequest.connectedWithUserId)) {
             return false;
         }

--- a/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
@@ -4,7 +4,7 @@ import com.google.gson.Gson;
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.controllers.dto.ConnectRequest;
-import com.savvato.tribeapp.controllers.dto.ConnectionDeleteRequest;
+import com.savvato.tribeapp.controllers.dto.ConnectionRemovalRequest;
 import com.savvato.tribeapp.entities.User;
 import com.savvato.tribeapp.entities.UserRole;
 import com.savvato.tribeapp.services.*;
@@ -196,11 +196,11 @@ public class ConnectAPITest {
                 .thenReturn(new UserPrincipal(user));
         String auth = AuthServiceImpl.generateAccessToken(user);
 
-        ConnectionDeleteRequest connectionDeleteRequest = new ConnectionDeleteRequest();
+        ConnectionRemovalRequest connectionDeleteRequest = new ConnectionRemovalRequest();
         connectionDeleteRequest.requestingUserId = 1L;
         connectionDeleteRequest.connectedWithUserId = 2L;
         when(connectService.removeConnection(any())).thenReturn(true);
-        ArgumentCaptor<ConnectionDeleteRequest> connectionDeleteRequestCaptor = ArgumentCaptor.forClass(ConnectionDeleteRequest.class);
+        ArgumentCaptor<ConnectionRemovalRequest> connectionDeleteRequestCaptor = ArgumentCaptor.forClass(ConnectionRemovalRequest.class);
         this.mockMvc
                 .perform(
                         delete("/api/connect")
@@ -222,11 +222,11 @@ public class ConnectAPITest {
                 .thenReturn(new UserPrincipal(user));
         String auth = AuthServiceImpl.generateAccessToken(user);
 
-        ConnectionDeleteRequest connectionDeleteRequest = new ConnectionDeleteRequest();
+        ConnectionRemovalRequest connectionDeleteRequest = new ConnectionRemovalRequest();
         connectionDeleteRequest.requestingUserId = 1L;
         connectionDeleteRequest.connectedWithUserId = 2L;
         when(connectService.removeConnection(any())).thenReturn(false);
-        ArgumentCaptor<ConnectionDeleteRequest> connectionDeleteRequestCaptor = ArgumentCaptor.forClass(ConnectionDeleteRequest.class);
+        ArgumentCaptor<ConnectionRemovalRequest> connectionDeleteRequestCaptor = ArgumentCaptor.forClass(ConnectionRemovalRequest.class);
         this.mockMvc
                 .perform(
                         delete("/api/connect")

--- a/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.controllers.dto.ConnectRequest;
+import com.savvato.tribeapp.controllers.dto.ConnectionDeleteRequest;
 import com.savvato.tribeapp.entities.User;
 import com.savvato.tribeapp.entities.UserRole;
 import com.savvato.tribeapp.services.*;
@@ -24,11 +25,13 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -187,5 +190,55 @@ public class ConnectAPITest {
         assertEquals(toBeConnectedWithUserIdCaptor.getValue(), connectRequest.toBeConnectedWithUserId);
     }
 
+    @Test
+    public void removeConnectionHappyPath() throws Exception {
+        when(userPrincipalService.getUserPrincipalByEmail(Mockito.anyString()))
+                .thenReturn(new UserPrincipal(user));
+        String auth = AuthServiceImpl.generateAccessToken(user);
 
+        ConnectionDeleteRequest connectionDeleteRequest = new ConnectionDeleteRequest();
+        connectionDeleteRequest.requestingUserId = 1L;
+        connectionDeleteRequest.connectedWithUserId = 2L;
+        when(connectService.removeConnection(any())).thenReturn(true);
+        ArgumentCaptor<ConnectionDeleteRequest> connectionDeleteRequestCaptor = ArgumentCaptor.forClass(ConnectionDeleteRequest.class);
+        this.mockMvc
+                .perform(
+                        delete("/api/connect")
+                                .content(gson.toJson(connectionDeleteRequest))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer " + auth)
+                                .characterEncoding("utf-8"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("true"))
+                .andReturn();
+        verify(connectService, times(1)).removeConnection(connectionDeleteRequestCaptor.capture());
+        assertThat(connectionDeleteRequestCaptor.getValue()).usingRecursiveComparison().isEqualTo(connectionDeleteRequest);
+
+    }
+
+    @Test
+    public void removeConnectionWhenRemovalUnsuccessful() throws Exception {
+        when(userPrincipalService.getUserPrincipalByEmail(Mockito.anyString()))
+                .thenReturn(new UserPrincipal(user));
+        String auth = AuthServiceImpl.generateAccessToken(user);
+
+        ConnectionDeleteRequest connectionDeleteRequest = new ConnectionDeleteRequest();
+        connectionDeleteRequest.requestingUserId = 1L;
+        connectionDeleteRequest.connectedWithUserId = 2L;
+        when(connectService.removeConnection(any())).thenReturn(false);
+        ArgumentCaptor<ConnectionDeleteRequest> connectionDeleteRequestCaptor = ArgumentCaptor.forClass(ConnectionDeleteRequest.class);
+        this.mockMvc
+                .perform(
+                        delete("/api/connect")
+                                .content(gson.toJson(connectionDeleteRequest))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer " + auth)
+                                .characterEncoding("utf-8"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("false"))
+                .andReturn();
+        verify(connectService, times(1)).removeConnection(connectionDeleteRequestCaptor.capture());
+        assertThat(connectionDeleteRequestCaptor.getValue()).usingRecursiveComparison().isEqualTo(connectionDeleteRequest);
+
+    }
 }

--- a/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.savvato.tribeapp.services;
 
 import com.savvato.tribeapp.config.principal.UserPrincipal;
+import com.savvato.tribeapp.controllers.dto.ConnectionDeleteRequest;
 import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
 import com.savvato.tribeapp.dto.ConnectOutgoingMessageDTO;
 import com.savvato.tribeapp.entities.Connection;
@@ -23,8 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith({SpringExtension.class})
@@ -233,5 +233,41 @@ public class ConnectServiceImplTest extends AbstractServiceImplTest {
         doReturn(qrCodeOpt).when(connectServiceSpy).getQRCodeString(anyLong());
         Boolean isValid = connectServiceSpy.validateQRCode(providedQRCode, toBeConnectedWithUserId);
         assertTrue(isValid);
+    }
+
+    @Test
+    public void removeConnectionHappyPath() {
+        ConnectionDeleteRequest connectionDeleteRequest = new ConnectionDeleteRequest();
+        connectionDeleteRequest.requestingUserId = 1L;
+        connectionDeleteRequest.connectedWithUserId = 2L;
+        ArgumentCaptor<Long> requestingUserIdCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Long> connectedWithUserIdCaptor = ArgumentCaptor.forClass(Long.class);
+        assertTrue(connectService.removeConnection(connectionDeleteRequest));
+        verify(connectionsRepository, times(1)).removeConnection(requestingUserIdCaptor.capture(), connectedWithUserIdCaptor.capture());
+        assertEquals(requestingUserIdCaptor.getValue(), connectionDeleteRequest.requestingUserId);
+        assertEquals(connectedWithUserIdCaptor.getValue(), connectionDeleteRequest.connectedWithUserId);
+    }
+
+    @Test
+    public void removeConnectionWhenDatabaseDeleteFails() {
+        ConnectionDeleteRequest connectionDeleteRequest = new ConnectionDeleteRequest();
+        connectionDeleteRequest.requestingUserId = 1L;
+        connectionDeleteRequest.connectedWithUserId = 2L;
+        ArgumentCaptor<Long> requestingUserIdCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Long> connectedWithUserIdCaptor = ArgumentCaptor.forClass(Long.class);
+        doThrow(new IllegalArgumentException("Database delete failed.")).when(connectionsRepository).removeConnection(anyLong(), anyLong());
+        assertFalse(connectService.removeConnection(connectionDeleteRequest));
+        verify(connectionsRepository, times(1)).removeConnection(requestingUserIdCaptor.capture(), connectedWithUserIdCaptor.capture());
+        assertEquals(requestingUserIdCaptor.getValue(), connectionDeleteRequest.requestingUserId);
+        assertEquals(connectedWithUserIdCaptor.getValue(), connectionDeleteRequest.connectedWithUserId);
+    }
+
+    @Test
+    public void removeConnectionWhenBothIdsAreTheSame() {
+        ConnectionDeleteRequest connectionDeleteRequest = new ConnectionDeleteRequest();
+        connectionDeleteRequest.requestingUserId = 1L;
+        connectionDeleteRequest.connectedWithUserId = 1L;
+        assertFalse(connectService.removeConnection(connectionDeleteRequest));
+        verify(connectionsRepository, never()).removeConnection(anyLong(), anyLong());
     }
 }

--- a/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.savvato.tribeapp.services;
 
 import com.savvato.tribeapp.config.principal.UserPrincipal;
-import com.savvato.tribeapp.controllers.dto.ConnectionDeleteRequest;
+import com.savvato.tribeapp.controllers.dto.ConnectionRemovalRequest;
 import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
 import com.savvato.tribeapp.dto.ConnectOutgoingMessageDTO;
 import com.savvato.tribeapp.entities.Connection;
@@ -237,7 +237,7 @@ public class ConnectServiceImplTest extends AbstractServiceImplTest {
 
     @Test
     public void removeConnectionHappyPath() {
-        ConnectionDeleteRequest connectionDeleteRequest = new ConnectionDeleteRequest();
+        ConnectionRemovalRequest connectionDeleteRequest = new ConnectionRemovalRequest();
         connectionDeleteRequest.requestingUserId = 1L;
         connectionDeleteRequest.connectedWithUserId = 2L;
         ArgumentCaptor<Long> requestingUserIdCaptor = ArgumentCaptor.forClass(Long.class);
@@ -250,7 +250,7 @@ public class ConnectServiceImplTest extends AbstractServiceImplTest {
 
     @Test
     public void removeConnectionWhenDatabaseDeleteFails() {
-        ConnectionDeleteRequest connectionDeleteRequest = new ConnectionDeleteRequest();
+        ConnectionRemovalRequest connectionDeleteRequest = new ConnectionRemovalRequest();
         connectionDeleteRequest.requestingUserId = 1L;
         connectionDeleteRequest.connectedWithUserId = 2L;
         ArgumentCaptor<Long> requestingUserIdCaptor = ArgumentCaptor.forClass(Long.class);
@@ -264,10 +264,10 @@ public class ConnectServiceImplTest extends AbstractServiceImplTest {
 
     @Test
     public void removeConnectionWhenBothIdsAreTheSame() {
-        ConnectionDeleteRequest connectionDeleteRequest = new ConnectionDeleteRequest();
-        connectionDeleteRequest.requestingUserId = 1L;
-        connectionDeleteRequest.connectedWithUserId = 1L;
-        assertFalse(connectService.removeConnection(connectionDeleteRequest));
+        ConnectionRemovalRequest connectionRemovalRequest = new ConnectionRemovalRequest();
+        connectionRemovalRequest.requestingUserId = 1L;
+        connectionRemovalRequest.connectedWithUserId = 1L;
+        assertFalse(connectService.removeConnection(connectionRemovalRequest));
         verify(connectionsRepository, never()).removeConnection(anyLong(), anyLong());
     }
 }


### PR DESCRIPTION
This PR addresses TRIB-105 and creates a DELETE endpoint for removing a connection. The following changes are made:
- Add repository method for deleting connection from connections table in DB
- Create ConnectionRemovalRequestDTO containing the user IDs of the connected users
- Create relevant service method, controller endpoint, endpoint Swagger annotation
- Write relevant unit tests 