### PR TITLE
TRIB-210: adds save cosign endpoint

### DIFF
--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -9,6 +9,7 @@ import com.savvato.tribeapp.controllers.dto.ConnectRequest;
 import com.savvato.tribeapp.controllers.dto.CosignRequest;
 import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
 import com.savvato.tribeapp.dto.ConnectOutgoingMessageDTO;
+import com.savvato.tribeapp.dto.CosignDTO;
 import com.savvato.tribeapp.services.ConnectService;
 import com.savvato.tribeapp.services.CosignService;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -89,10 +90,11 @@ public class ConnectAPIController {
 
   @SaveCosign
   @PostMapping("/cosign")
-  public ResponseEntity saveCosign(@RequestBody @Valid CosignRequest cosignRequest) {
+  public ResponseEntity<CosignDTO> saveCosign(@RequestBody @Valid CosignRequest cosignRequest) {
 
-      cosignService.saveCosign(cosignRequest.userIdIssuing, cosignRequest.userIdReceiving, cosignRequest.phraseId);
-      return ResponseEntity.status(HttpStatus.OK).build();
+      CosignDTO cosignDTO = cosignService.saveCosign(cosignRequest.userIdIssuing, cosignRequest.userIdReceiving, cosignRequest.phraseId);
+      
+      return ResponseEntity.status(HttpStatus.OK).body(cosignDTO);
 
   }
 }

--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -4,10 +4,12 @@ import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController.Connect;
 import com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController.GetConnections;
 import com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController.GetQRCodeString;
+import com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController.SaveCosign;
 import com.savvato.tribeapp.controllers.dto.ConnectRequest;
 import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
 import com.savvato.tribeapp.dto.ConnectOutgoingMessageDTO;
 import com.savvato.tribeapp.services.ConnectService;
+import com.savvato.tribeapp.services.CosignService;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -27,6 +29,9 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/connect")
 public class ConnectAPIController {
   @Autowired ConnectService connectService;
+
+  @Autowired
+  CosignService cosignService;
 
   ConnectAPIController() {}
 
@@ -79,5 +84,14 @@ public class ConnectAPIController {
   @MessageMapping("/connect/room")
   public void connect(@Payload ConnectIncomingMessageDTO incoming, @Header("simpSessionId") String sessionId) {
       connectService.connect(incoming);
+  }
+
+  @SaveCosign
+  @PostMapping("/cosign")
+  public ResponseEntity saveCosign(@Parameter(description = "User ID of user issuing cosign", example = "1") @RequestParam("userIdIssuing") Long userIdIssuing, @Parameter(description = "User ID of user receiving cosign", example = "1") @RequestParam("userIdReceiving") Long userIdReceiving, @Parameter(description = "Phrase ID of cosigned phrase", example = "1") @RequestParam("phraseId") Long phraseId) {
+
+      cosignService.saveCosign(userIdIssuing,userIdReceiving,phraseId);
+      return ResponseEntity.status(HttpStatus.OK).build();
+
   }
 }

--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -91,7 +91,7 @@ public class ConnectAPIController {
   @PostMapping("/cosign")
   public ResponseEntity saveCosign(@RequestBody @Valid CosignRequest cosignRequest) {
 
-      cosignService.saveCosign(cosignRequest);
+      cosignService.saveCosign(cosignRequest.userIdIssuing, cosignRequest.userIdReceiving, cosignRequest.phraseId);
       return ResponseEntity.status(HttpStatus.OK).build();
 
   }

--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -87,7 +87,7 @@ public class ConnectAPIController {
       connectService.connect(incoming);
   }
 
-  //@SaveCosign
+  @SaveCosign
   @PostMapping("/cosign")
   public ResponseEntity saveCosign(@RequestBody @Valid CosignRequest cosignRequest) {
 

--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -6,6 +6,7 @@ import com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIContro
 import com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController.GetQRCodeString;
 import com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController.SaveCosign;
 import com.savvato.tribeapp.controllers.dto.ConnectRequest;
+import com.savvato.tribeapp.controllers.dto.CosignRequest;
 import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
 import com.savvato.tribeapp.dto.ConnectOutgoingMessageDTO;
 import com.savvato.tribeapp.services.ConnectService;
@@ -86,11 +87,11 @@ public class ConnectAPIController {
       connectService.connect(incoming);
   }
 
-  @SaveCosign
+  //@SaveCosign
   @PostMapping("/cosign")
-  public ResponseEntity saveCosign(@Parameter(description = "User ID of user issuing cosign", example = "1") @RequestParam("userIdIssuing") Long userIdIssuing, @Parameter(description = "User ID of user receiving cosign", example = "1") @RequestParam("userIdReceiving") Long userIdReceiving, @Parameter(description = "Phrase ID of cosigned phrase", example = "1") @RequestParam("phraseId") Long phraseId) {
+  public ResponseEntity saveCosign(@RequestBody @Valid CosignRequest cosignRequest) {
 
-      cosignService.saveCosign(userIdIssuing,userIdReceiving,phraseId);
+      cosignService.saveCosign(cosignRequest);
       return ResponseEntity.status(HttpStatus.OK).build();
 
   }

--- a/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/ConnectAPIController/SaveCosign.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/ConnectAPIController/SaveCosign.java
@@ -13,5 +13,5 @@ import java.lang.annotation.*;
     summary = "Save a cosigned phrase applied to one user by another user.",
     description = "Provide an issuing user ID, receiving user ID and phrase ID, save as record in cosign table.")
 @Success(
-    description = "Successfully saved cosign.", noContent = true)
+    description = "Successfully saved cosign.")
 public @interface SaveCosign {}

--- a/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/ConnectAPIController/SaveCosign.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/ConnectAPIController/SaveCosign.java
@@ -1,0 +1,17 @@
+package com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController;
+
+import com.savvato.tribeapp.controllers.annotations.responses.Success;
+import io.swagger.v3.oas.annotations.Operation;
+
+import java.lang.annotation.*;
+
+/** Documentation for saving a cosign from one user to another*/
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+    summary = "Save a cosigned phrase applied to one user by another user.",
+    description = "Provide an issuing user ID, receiving user ID and phrase ID, save as record in cosign table.")
+@Success(
+    description = "Successfully saved cosign.", noContent = true)
+public @interface SaveCosign {}

--- a/src/main/java/com/savvato/tribeapp/controllers/dto/CosignRequest.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/dto/CosignRequest.java
@@ -1,0 +1,15 @@
+package com.savvato.tribeapp.controllers.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "A request containing a cosign's ids")
+public class CosignRequest {
+    @Schema(example = "1")
+    public Long userIdIssuing;
+
+    @Schema(example = "1")
+    public Long userIdReceiving;
+
+    @Schema(example = "1")
+    public Long phraseId;
+}

--- a/src/main/java/com/savvato/tribeapp/dto/CosignDTO.java
+++ b/src/main/java/com/savvato/tribeapp/dto/CosignDTO.java
@@ -1,0 +1,12 @@
+package com.savvato.tribeapp.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "A Cosign DTO")
+@Builder
+public class CosignDTO {
+    public Long userIdIssuing;
+    public Long userIdReceiving;
+    public Long phraseId;
+}

--- a/src/main/java/com/savvato/tribeapp/entities/Cosign.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Cosign.java
@@ -1,0 +1,44 @@
+package com.savvato.tribeapp.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+
+@Entity
+@IdClass(CosignId.class)
+public class Cosign {
+
+    @Id
+    public Long userIdIssuing;
+
+    @Id
+    public Long userIdReceiving;
+
+    @Id
+    public Long phraseId;
+
+    public Long getUserIdIssuing() {
+        return userIdIssuing;
+    }
+
+    public void setUserIdIssuing(Long userId) {
+        this.userIdIssuing = userId;
+    }
+
+    public Long getUserIdReceiving() {
+        return userIdReceiving;
+    }
+
+    public void setUserIdReceiving(Long userId) {
+        this.userIdReceiving = userId;
+    }
+
+    public Long getPhraseId() {
+        return phraseId;
+    }
+
+    public void setPhraseId(Long phraseId) {
+        this.phraseId = phraseId;
+    }
+
+}

--- a/src/main/java/com/savvato/tribeapp/entities/CosignId.java
+++ b/src/main/java/com/savvato/tribeapp/entities/CosignId.java
@@ -1,0 +1,21 @@
+package com.savvato.tribeapp.entities;
+
+import java.io.Serializable;
+
+public class CosignId implements Serializable {
+    private Long userIdIssuing;
+    private Long userIdReceiving;
+    private Long phraseId;
+
+    public Long getUserIdIssuing() { return userIdIssuing; }
+
+    public void setUserIdIssuing(Long userIdIssuing) { this.userIdIssuing = userIdIssuing; }
+
+    public Long getUserIdReceiving() { return userIdReceiving; }
+
+    public void setUserIdReceiving(Long userIdReceiving) { this.userIdReceiving = userIdReceiving; }
+
+    public Long getPhraseId() { return phraseId; }
+
+    public void setPhraseId(Long phraseId) { this.phraseId = phraseId; }
+}

--- a/src/main/java/com/savvato/tribeapp/repositories/CosignRepository.java
+++ b/src/main/java/com/savvato/tribeapp/repositories/CosignRepository.java
@@ -1,0 +1,11 @@
+package com.savvato.tribeapp.repositories;
+
+import com.savvato.tribeapp.entities.Cosign;
+import com.savvato.tribeapp.entities.CosignId;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CosignRepository extends CrudRepository<Cosign, CosignId> {
+
+}

--- a/src/main/java/com/savvato/tribeapp/services/CosignService.java
+++ b/src/main/java/com/savvato/tribeapp/services/CosignService.java
@@ -1,6 +1,10 @@
 package com.savvato.tribeapp.services;
 
+import com.savvato.tribeapp.dto.CosignDTO;
+
+import java.util.Optional;
+
 public interface CosignService {
 
-    void saveCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId);
+    CosignDTO saveCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId);
 }

--- a/src/main/java/com/savvato/tribeapp/services/CosignService.java
+++ b/src/main/java/com/savvato/tribeapp/services/CosignService.java
@@ -1,8 +1,6 @@
 package com.savvato.tribeapp.services;
 
-import com.savvato.tribeapp.controllers.dto.CosignRequest;
-
 public interface CosignService {
 
-    void saveCosign(CosignRequest cosignRequest);
+    void saveCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId);
 }

--- a/src/main/java/com/savvato/tribeapp/services/CosignService.java
+++ b/src/main/java/com/savvato/tribeapp/services/CosignService.java
@@ -1,6 +1,8 @@
 package com.savvato.tribeapp.services;
 
+import com.savvato.tribeapp.controllers.dto.CosignRequest;
+
 public interface CosignService {
 
-    void saveCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId);
+    void saveCosign(CosignRequest cosignRequest);
 }

--- a/src/main/java/com/savvato/tribeapp/services/CosignService.java
+++ b/src/main/java/com/savvato/tribeapp/services/CosignService.java
@@ -1,0 +1,6 @@
+package com.savvato.tribeapp.services;
+
+public interface CosignService {
+
+    void saveCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId);
+}

--- a/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
@@ -15,13 +15,13 @@ public class CosignServiceImpl implements CosignService {
     CosignRepository cosignRepository;
 
     @Override
-    public void saveCosign(CosignRequest cosignRequest) {
+    public void saveCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId) {
 
         Cosign cosign = new Cosign();
-        cosign.setUserIdIssuing(cosignRequest.userIdIssuing);
-        cosign.setUserIdReceiving(cosignRequest.userIdReceiving);
-        cosign.setPhraseId(cosignRequest.phraseId);
+        cosign.setUserIdIssuing(userIdIssuing);
+        cosign.setUserIdReceiving(userIdReceiving);
+        cosign.setPhraseId(phraseId);
         cosignRepository.save(cosign);
-        log.info("Cosign from user: " + cosignRequest.userIdIssuing + " to user: " + cosignRequest.userIdReceiving + " added." );
+        log.info("Cosign from user: " + userIdIssuing + " to user: " + userIdReceiving + " added." );
     }
 }

--- a/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
@@ -21,6 +21,7 @@ public class CosignServiceImpl implements CosignService {
         cosign.setUserIdIssuing(cosignRequest.userIdIssuing);
         cosign.setUserIdReceiving(cosignRequest.userIdReceiving);
         cosign.setPhraseId(cosignRequest.phraseId);
+        cosignRepository.save(cosign);
         log.info("Cosign from user: " + cosignRequest.userIdIssuing + " to user: " + cosignRequest.userIdReceiving + " added." );
     }
 }

--- a/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
@@ -1,5 +1,6 @@
 package com.savvato.tribeapp.services;
 
+import com.savvato.tribeapp.controllers.dto.CosignRequest;
 import com.savvato.tribeapp.entities.Cosign;
 import com.savvato.tribeapp.repositories.CosignRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -14,13 +15,13 @@ public class CosignServiceImpl implements CosignService {
     CosignRepository cosignRepository;
 
     @Override
-    public void saveCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId) {
+    public void saveCosign(CosignRequest cosignRequest) {
 
         Cosign cosign = new Cosign();
-        cosign.setUserIdIssuing(userIdIssuing);
-        cosign.setUserIdReceiving(userIdReceiving);
-        cosign.setPhraseId(phraseId);
+        cosign.setUserIdIssuing(cosignRequest.userIdIssuing);
+        cosign.setUserIdReceiving(cosign.userIdReceiving);
+        cosign.setPhraseId(cosign.phraseId);
         cosignRepository.save(cosign);
-        log.info("Cosign from user: " + userIdIssuing + " to user: " + userIdReceiving + " added." );
+        log.info("Cosign from user: " + cosignRequest.userIdIssuing + " to user: " + cosignRequest.userIdReceiving + " added." );
     }
 }

--- a/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
@@ -1,11 +1,14 @@
 package com.savvato.tribeapp.services;
 
 import com.savvato.tribeapp.controllers.dto.CosignRequest;
+import com.savvato.tribeapp.dto.CosignDTO;
 import com.savvato.tribeapp.entities.Cosign;
 import com.savvato.tribeapp.repositories.CosignRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @Slf4j
@@ -15,13 +18,23 @@ public class CosignServiceImpl implements CosignService {
     CosignRepository cosignRepository;
 
     @Override
-    public void saveCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId) {
+    public CosignDTO saveCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId) {
 
         Cosign cosign = new Cosign();
         cosign.setUserIdIssuing(userIdIssuing);
         cosign.setUserIdReceiving(userIdReceiving);
         cosign.setPhraseId(phraseId);
-        cosignRepository.save(cosign);
+
+        Cosign savedCosign = cosignRepository.save(cosign);
         log.info("Cosign from user: " + userIdIssuing + " to user: " + userIdReceiving + " added." );
+
+        CosignDTO cosignDTO = CosignDTO
+                .builder()
+                .userIdIssuing(savedCosign.getUserIdIssuing())
+                .userIdReceiving(savedCosign.getUserIdReceiving())
+                .phraseId(savedCosign.getPhraseId())
+                .build();
+
+        return cosignDTO;
     }
 }

--- a/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
@@ -1,0 +1,26 @@
+package com.savvato.tribeapp.services;
+
+import com.savvato.tribeapp.entities.Cosign;
+import com.savvato.tribeapp.repositories.CosignRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class CosignServiceImpl implements CosignService {
+
+    @Autowired
+    CosignRepository cosignRepository;
+
+    @Override
+    public void saveCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId) {
+
+        Cosign cosign = new Cosign();
+        cosign.setUserIdIssuing(userIdIssuing);
+        cosign.setUserIdReceiving(userIdReceiving);
+        cosign.setPhraseId(phraseId);
+        cosignRepository.save(cosign);
+        log.info("Cosign from user: " + userIdIssuing + " to user: " + userIdReceiving + " added." );
+    }
+}

--- a/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
@@ -19,9 +19,8 @@ public class CosignServiceImpl implements CosignService {
 
         Cosign cosign = new Cosign();
         cosign.setUserIdIssuing(cosignRequest.userIdIssuing);
-        cosign.setUserIdReceiving(cosign.userIdReceiving);
-        cosign.setPhraseId(cosign.phraseId);
-        cosignRepository.save(cosign);
+        cosign.setUserIdReceiving(cosignRequest.userIdReceiving);
+        cosign.setPhraseId(cosignRequest.phraseId);
         log.info("Cosign from user: " + cosignRequest.userIdIssuing + " to user: " + cosignRequest.userIdReceiving + " added." );
     }
 }

--- a/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
@@ -26,7 +26,7 @@ public class CosignServiceImpl implements CosignService {
         cosign.setPhraseId(phraseId);
 
         Cosign savedCosign = cosignRepository.save(cosign);
-        log.info("Cosign from user: " + userIdIssuing + " to user: " + userIdReceiving + " added." );
+        log.info("Cosign from user " + userIdIssuing + " to user " + userIdReceiving + " added." );
 
         CosignDTO cosignDTO = CosignDTO
                 .builder()

--- a/src/main/resources/db/migration/changelog-202401110955.xml
+++ b/src/main/resources/db/migration/changelog-202401110955.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="audra" id="202401110955-01">
+
+        <createTable tableName="cosign" catalogName="tribeapp_db" >
+            <column name="user_id_issuing" type="BIGINT(20)">
+                <constraints nullable="false" foreignKeyName="cosign_fk1" references="user(id)"/>
+            </column>
+            <column name="user_id_receiving" type="BIGINT(20)">
+                <constraints nullable="false" foreignKeyName="cosign_fk2" references="user(id)"/>
+            </column>
+            <column name="phrase_id" type="BIGINT(20)">
+                <constraints nullable="false" foreignKeyName="cosign_fk3" references="phrase(id)"/>
+            </column>
+        </createTable>
+
+    </changeSet>
+    
+</databaseChangeLog>
+

--- a/src/main/resources/db/migration/changelog-202401111012.xml
+++ b/src/main/resources/db/migration/changelog-202401111012.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="audra" id="202401111012-01" context="test">
+        <sql dbms="mysql">
+
+            <!-- one user cosigns a phrase for one user -->
+            INSERT INTO cosign (user_id_issuing, user_id_receiving, phrase_id)
+            VALUES (1,4,3);
+
+            <!-- one user cosigns same phrase for two users -->
+            INSERT INTO cosign (user_id_issuing, user_id_receiving, phrase_id)
+            VALUES (1,2,1);
+
+            INSERT INTO cosign (user_id_issuing, user_id_receiving, phrase_id)
+            VALUES (1,3,1);
+
+            <!-- two users cosign same phrase for one user -->
+            INSERT INTO cosign (user_id_issuing, user_id_receiving, phrase_id)
+            VALUES (2,1,2);
+
+            INSERT INTO cosign (user_id_issuing, user_id_receiving, phrase_id)
+            VALUES (3,1,2);
+
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-master.xml
+++ b/src/main/resources/db/migration/changelog-master.xml
@@ -42,6 +42,8 @@
     <include file="changelog-202309050841.xml" relativeToChangelogFile="true"/>
     <include file="changelog-202309141950.xml" relativeToChangelogFile="true"/>
     <include file="changelog-202311141812.xml" relativeToChangelogFile="true"/>
+    <include file="changelog-202401110955.xml" relativeToChangelogFile="true"/>
+    <include file="changelog-202401111012.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>
 

--- a/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
@@ -5,6 +5,7 @@ import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.controllers.dto.ConnectRequest;
 import com.savvato.tribeapp.controllers.dto.CosignRequest;
+import com.savvato.tribeapp.dto.CosignDTO;
 import com.savvato.tribeapp.entities.User;
 import com.savvato.tribeapp.entities.UserRole;
 import com.savvato.tribeapp.repositories.CosignRepository;
@@ -199,24 +200,33 @@ public class ConnectAPITest {
         when(userPrincipalService.getUserPrincipalByEmail(Mockito.anyString()))
                 .thenReturn(new UserPrincipal(user));
         String auth = AuthServiceImpl.generateAccessToken(user);
+
+        Long userIdIssuing = 1L;
+        Long userIdReceiving = 1L;
+        Long phraseId = 1L;
+
         CosignRequest cosignRequest = new CosignRequest();
+        cosignRequest.userIdIssuing = userIdIssuing;
+        cosignRequest.userIdReceiving = userIdReceiving;
+        cosignRequest.phraseId = phraseId;
 
-        cosignRequest.userIdIssuing = 1L;
-        cosignRequest.userIdReceiving = 2L;
-        cosignRequest.phraseId = 1L;
+        CosignDTO cosignDTO = CosignDTO.builder().build();
+        cosignDTO.userIdIssuing = userIdIssuing;
+        cosignDTO.userIdReceiving = userIdReceiving;
+        cosignDTO.phraseId = phraseId;
 
-        // to be implemented
+        when(cosignService.saveCosign(anyLong(), anyLong(), anyLong())).thenReturn(cosignDTO);
 
         this.mockMvc
                 .perform(
-                        post("/api/connect")
+                        post("/api/connect/cosign")
                                 .content(gson.toJson(cosignRequest))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header("Authorization", "Bearer " + auth)
                                 .characterEncoding("utf-8"))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(content().json("{\"userIdIssuing\":1,\"userIdReceiving\":1,\"phraseId\":1}"));
 
-        // to be implemented
     }
 
 }

--- a/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
@@ -4,8 +4,10 @@ import com.google.gson.Gson;
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.controllers.dto.ConnectRequest;
+import com.savvato.tribeapp.controllers.dto.CosignRequest;
 import com.savvato.tribeapp.entities.User;
 import com.savvato.tribeapp.entities.UserRole;
+import com.savvato.tribeapp.repositories.CosignRepository;
 import com.savvato.tribeapp.services.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,6 +57,11 @@ public class ConnectAPITest {
 
     @MockBean
     private ConnectService connectService;
+
+    @MockBean CosignService cosignService;
+
+    @MockBean
+    private CosignRepository repository;
 
     @Captor
     private ArgumentCaptor<Long> userIdCaptor;
@@ -187,5 +194,29 @@ public class ConnectAPITest {
         assertEquals(toBeConnectedWithUserIdCaptor.getValue(), connectRequest.toBeConnectedWithUserId);
     }
 
+    @Test
+    public void saveCosign() throws Exception {
+        when(userPrincipalService.getUserPrincipalByEmail(Mockito.anyString()))
+                .thenReturn(new UserPrincipal(user));
+        String auth = AuthServiceImpl.generateAccessToken(user);
+        CosignRequest cosignRequest = new CosignRequest();
+
+        cosignRequest.userIdIssuing = 1L;
+        cosignRequest.userIdReceiving = 2L;
+        cosignRequest.phraseId = 1L;
+
+        // to be implemented
+
+        this.mockMvc
+                .perform(
+                        post("/api/connect")
+                                .content(gson.toJson(cosignRequest))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer " + auth)
+                                .characterEncoding("utf-8"))
+                .andExpect(status().isOk());
+
+        // to be implemented
+    }
 
 }

--- a/src/test/java/com/savvato/tribeapp/services/CosignServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/CosignServiceImplTest.java
@@ -3,11 +3,15 @@ package com.savvato.tribeapp.services;
 import com.savvato.tribeapp.repositories.CosignRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith({SpringExtension.class})
 public class CosignServiceImplTest extends AbstractServiceImplTest{
@@ -30,6 +34,12 @@ public class CosignServiceImplTest extends AbstractServiceImplTest{
 
     @Test
     public void saveCosign() {
+        Long userIdIssuing = 1L;
+        Long userIdReceiving = 1L;
+        Long phraseId = 1L;
+
+        cosignService.saveCosign(userIdIssuing, userIdReceiving, phraseId);
+        verify(cosignRepository, times(1)).save(Mockito.any());
 
     }
 }

--- a/src/test/java/com/savvato/tribeapp/services/CosignServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/CosignServiceImplTest.java
@@ -1,5 +1,7 @@
 package com.savvato.tribeapp.services;
 
+import com.savvato.tribeapp.dto.CosignDTO;
+import com.savvato.tribeapp.entities.Cosign;
 import com.savvato.tribeapp.repositories.CosignRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,8 +12,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static net.bytebuddy.matcher.ElementMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
 
 @ExtendWith({SpringExtension.class})
 public class CosignServiceImplTest extends AbstractServiceImplTest{
@@ -38,8 +41,23 @@ public class CosignServiceImplTest extends AbstractServiceImplTest{
         Long userIdReceiving = 1L;
         Long phraseId = 1L;
 
-        cosignService.saveCosign(userIdIssuing, userIdReceiving, phraseId);
-        verify(cosignRepository, times(1)).save(Mockito.any());
+        Cosign cosign = new Cosign();
+        cosign.setUserIdIssuing(userIdIssuing);
+        cosign.setUserIdReceiving(userIdReceiving);
+        cosign.setPhraseId(phraseId);
 
+        CosignDTO cosignDTO = CosignDTO.builder().build();
+        cosignDTO.userIdIssuing = userIdIssuing;
+        cosignDTO.userIdReceiving = userIdReceiving;
+        cosignDTO.phraseId = phraseId;
+
+        when(cosignRepository.save(Mockito.any())).thenReturn(cosign);
+
+        CosignDTO expectedCosignDTO = cosignService.saveCosign(userIdIssuing, userIdReceiving, phraseId);
+
+        verify(cosignRepository, times(1)).save(Mockito.any());
+        assertEquals(cosignDTO.userIdIssuing, expectedCosignDTO.userIdIssuing);
+        assertEquals(cosignDTO.userIdReceiving, expectedCosignDTO.userIdReceiving);
+        assertEquals(cosignDTO.phraseId, expectedCosignDTO.phraseId);
     }
 }

--- a/src/test/java/com/savvato/tribeapp/services/CosignServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/CosignServiceImplTest.java
@@ -60,4 +60,35 @@ public class CosignServiceImplTest extends AbstractServiceImplTest{
         assertEquals(cosignDTO.userIdReceiving, expectedCosignDTO.userIdReceiving);
         assertEquals(cosignDTO.phraseId, expectedCosignDTO.phraseId);
     }
+
+    @Test
+    public void saveCosignAlreadyExisting() {
+        Long userIdIssuing = 1L;
+        Long userIdReceiving = 1L;
+        Long phraseId = 1L;
+
+        Cosign cosign = new Cosign();
+        cosign.setUserIdIssuing(userIdIssuing);
+        cosign.setUserIdReceiving(userIdReceiving);
+        cosign.setPhraseId(phraseId);
+
+        CosignDTO cosignDTO = CosignDTO.builder().build();
+        cosignDTO.userIdIssuing = userIdIssuing;
+        cosignDTO.userIdReceiving = userIdReceiving;
+        cosignDTO.phraseId = phraseId;
+
+        when(cosignRepository.save(Mockito.any())).thenReturn(cosign).thenReturn(cosign);
+
+        CosignDTO expectedCosignDTO = cosignService.saveCosign(userIdIssuing, userIdReceiving, phraseId);
+
+        assertEquals(cosignDTO.userIdIssuing, expectedCosignDTO.userIdIssuing);
+        assertEquals(cosignDTO.userIdReceiving, expectedCosignDTO.userIdReceiving);
+        assertEquals(cosignDTO.phraseId, expectedCosignDTO.phraseId);
+
+        CosignDTO expectedCosignDTORepeat = cosignService.saveCosign(userIdIssuing, userIdReceiving, phraseId);
+
+        assertEquals(cosignDTO.userIdIssuing, expectedCosignDTORepeat.userIdIssuing);
+        assertEquals(cosignDTO.userIdReceiving, expectedCosignDTORepeat.userIdReceiving);
+        assertEquals(cosignDTO.phraseId, expectedCosignDTORepeat.phraseId);
+    }
 }

--- a/src/test/java/com/savvato/tribeapp/services/CosignServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/CosignServiceImplTest.java
@@ -1,0 +1,35 @@
+package com.savvato.tribeapp.services;
+
+import com.savvato.tribeapp.repositories.CosignRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith({SpringExtension.class})
+public class CosignServiceImplTest extends AbstractServiceImplTest{
+
+    @TestConfiguration
+    static class CosignServiceImplTestContextConfiguration {
+
+        @Bean
+        public  CosignService cosignService() {
+            return new CosignServiceImpl();
+        }
+
+    }
+
+    @Autowired
+    CosignService cosignService;
+
+    @MockBean
+    CosignRepository cosignRepository;
+
+    @Test
+    public void saveCosign() {
+
+    }
+}

--- a/src/test/java/com/savvato/tribeapp/services/StorageServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/StorageServiceImplTest.java
@@ -95,6 +95,40 @@ public class StorageServiceImplTest {
 
         long result = storageService.isFileExisting(resourceType, filename);
         assertTrue(result == 0);
-        
+
+    }
+
+    @Test
+    public void deleteHappyPath() throws IOException {
+        String resourceType = "testResourceType";
+        String filename = "testFile.txt";
+        String directoryPath = System.getProperty("java.io.tmpdir") + File.separator + "testFiles";
+
+        // Create the directory if it doesn't exist
+        File directory = new File(directoryPath);
+        directory.mkdirs();
+
+        // Create a temporary file in the specified directory
+        File tempFile = new File(directory, filename);
+        tempFile.createNewFile();
+
+        when(resourceTypeService.getDirectoryForResourceType(anyString())).thenReturn(directoryPath);
+
+        try {
+            // confirm new temporary file exists
+            long result = storageService.isFileExisting(resourceType, filename);
+            if(result > 0) {
+                // delete file and confirm it is deleted
+                storageService.delete(resourceType, filename);
+                long resultAfterDelete = storageService.isFileExisting(resourceType, filename);
+                assertEquals(0, resultAfterDelete);
+            }
+        } finally {
+            // Clean up: Delete the temporary file
+            tempFile.delete();
+
+            // Clean up: Delete the temporary directory
+            directory.delete();
+        }
     }
 }

--- a/src/test/java/com/savvato/tribeapp/services/StorageServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/StorageServiceImplTest.java
@@ -10,8 +10,15 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.multipart.MultipartFile;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
@@ -48,5 +55,33 @@ public class StorageServiceImplTest {
         String filename = "";
         when(resourceTypeService.getDirectoryForResourceType(anyString())).thenReturn(dir);
         storageService.store(resourceType, file, filename);
+    }
+
+    @Test
+    public void isFileExistingHappyPath() throws IOException {
+        String resourceType = "testResourceType";
+        String filename = "testFile.txt";
+        String directoryPath = System.getProperty("java.io.tmpdir") + File.separator + "testFiles";
+
+        // Create the directory if it doesn't exist
+        File directory = new File(directoryPath);
+        directory.mkdirs();
+
+        // Create a temporary file in the specified directory
+        File tempFile = new File(directory, filename);
+        tempFile.createNewFile();
+
+        when(resourceTypeService.getDirectoryForResourceType(anyString())).thenReturn(directoryPath);
+
+        try {
+            long result = storageService.isFileExisting(resourceType, filename);
+            assertTrue(result > 0);
+        } finally {
+            // Clean up: Delete the temporary file
+            tempFile.delete();
+
+            // Clean up: Delete the temporary directory
+            directory.delete();
+        }
     }
 }

--- a/src/test/java/com/savvato/tribeapp/services/StorageServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/StorageServiceImplTest.java
@@ -84,4 +84,17 @@ public class StorageServiceImplTest {
             directory.delete();
         }
     }
+
+    @Test
+    public void isFileExistingSadPath() throws IOException {
+        String resourceType = "testResourceType";
+        String filename = "testFile.txt";
+        String directoryPath = "/";
+
+        when(resourceTypeService.getDirectoryForResourceType(anyString())).thenReturn(directoryPath);
+
+        long result = storageService.isFileExisting(resourceType, filename);
+        assertTrue(result == 0);
+        
+    }
 }


### PR DESCRIPTION
Note: I am submitting this early (with questions and incomplete test) to review at our meeting 1/11/2024

Questions: 
1. Do we want a return value from the saveCosign endpoint
2. Do we agree: Cosign endpoint is in Connect Controller, Cosign service and repo are separate

Changes:
- Creates Database table for cosign
- Creates Database table with cosign test data
- Creates Cosign and CosignID entities
- Creates Cosign repository
- Creates Cosign service and Impl with saveCosign method
- Adds saveCosign endpoint to Connect Service and creates CosignRequest DTO and annotation

Testing (WIP)
- Adds Cosign service test for saveCosign (simple, without return values)
- Adds Connect API test  for save Cosign (INCOMPLETE AS OF 1/11)