### PR TITLE
TRIB-142: updates ConnectAPI endpoint for getting all connections for a user

### DIFF
--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -46,7 +46,7 @@ public class ConnectAPIController {
   ConnectAPIController() {}
 
   @GetConnections
-  @GetMapping("/all/{userId}")
+  @GetMapping("/{userId}/all")
   public ResponseEntity<List<ConnectOutgoingMessageDTO>> getConnections(
       @Parameter(description = "The user ID of a user", example = "1") @PathVariable Long userId) {
 

--- a/src/main/java/com/savvato/tribeapp/entities/Connection.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Connection.java
@@ -12,8 +12,7 @@ public class Connection {
 
     private Long requestingUserId;
     private Long toBeConnectedWithUserId;
-    private java.sql.Timestamp createdTimestamp;
-
+    private java.sql.Timestamp createdAt;
     public Long getId() {
         return id;
     }
@@ -39,11 +38,11 @@ public class Connection {
     }
 
     public java.sql.Timestamp getCreated() {
-        return createdTimestamp;
+        return createdAt;
     }
 
     public void setCreated() {
-        this.createdTimestamp = java.sql.Timestamp.from(Calendar.getInstance().toInstant());
+        this.createdAt = java.sql.Timestamp.from(Calendar.getInstance().toInstant());
     }
 
     public Connection(Long requestingUserId, Long toBeConnectedWithUserId) {

--- a/src/main/resources/db/migration/changelog-202401291541.xml
+++ b/src/main/resources/db/migration/changelog-202401291541.xml
@@ -5,7 +5,6 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <!-- Alters phrase table to NOT accept null values -->
     <changeSet author="audra" id="202401291541-01">
         <sql dbms="mysql">
             ALTER TABLE connections RENAME COLUMN `requestingUserId` TO requesting_user_id;

--- a/src/main/resources/db/migration/changelog-202401291541.xml
+++ b/src/main/resources/db/migration/changelog-202401291541.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <!-- Alters phrase table to NOT accept null values -->
+    <changeSet author="audra" id="202401291541-01">
+        <sql dbms="mysql">
+            ALTER TABLE connections RENAME COLUMN `requestingUserId` TO requesting_user_id;
+            ALTER TABLE connections RENAME COLUMN `toBeConnectedWithUserId` TO to_be_connected_with_user_id;
+            ALTER TABLE connections RENAME COLUMN `createdAt` TO created_at;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-master.xml
+++ b/src/main/resources/db/migration/changelog-master.xml
@@ -44,6 +44,7 @@
     <include file="changelog-202311141812.xml" relativeToChangelogFile="true"/>
     <include file="changelog-202401110955.xml" relativeToChangelogFile="true"/>
     <include file="changelog-202401111012.xml" relativeToChangelogFile="true"/>
+    <include file="changelog-202401291541.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>
 

--- a/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
@@ -301,9 +301,6 @@ public class ConnectAPITest {
         List requestingUserIds = new ArrayList<Long>();
         requestingUserIds.add(2L);
 
-        //List expectedUserToBeReviewedList = new ArrayList<>();
-        //expectedUserToBeReviewedList.add(toBeConnectedWithUserId);
-
         ConnectOutgoingMessageDTO returnDTO = ConnectOutgoingMessageDTO
                 .builder()
                 .connectionError(null)

--- a/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
@@ -332,4 +332,25 @@ public class ConnectAPITest {
         assertThat(actualConnectOutingMessages).usingRecursiveComparison().isEqualTo(expectedReturnDtoList);
     }
 
+    @Test
+    public void testGetConnectionsSadPath() throws Exception {
+        when(userPrincipalService.getUserPrincipalByEmail(Mockito.anyString()))
+                .thenReturn(new UserPrincipal(user));
+        String auth = AuthServiceImpl.generateAccessToken(user);
+
+        Long userId = 1L;
+
+        when(connectService.getAllConnectionsForAUser(anyLong())).thenReturn(null);
+
+        MvcResult result =
+                this.mockMvc
+                        .perform(
+                                get("/api/connect/{userId}/all", userId)
+                                        .header("Authorization", "Bearer " + auth)
+                                        .characterEncoding("utf-8"))
+                        .andExpect(status().isBadRequest())
+                        .andReturn();
+
+    }
+
 }

--- a/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
@@ -297,17 +297,19 @@ public class ConnectAPITest {
                 .thenReturn(new UserPrincipal(user));
         String auth = AuthServiceImpl.generateAccessToken(user);
 
-        Long userId = 1L;
+        Long toBeConnectedWithUserId = 1L;
+        List requestingUserIds = new ArrayList<Long>();
+        requestingUserIds.add(2L);
 
-        List expectedUserToBeReviewedList = new ArrayList<>();
-        expectedUserToBeReviewedList.add(userId);
+        //List expectedUserToBeReviewedList = new ArrayList<>();
+        //expectedUserToBeReviewedList.add(toBeConnectedWithUserId);
 
         ConnectOutgoingMessageDTO returnDTO = ConnectOutgoingMessageDTO
                 .builder()
                 .connectionError(null)
                 .connectionSuccess(true)
                 .message("")
-                .to(expectedUserToBeReviewedList)
+                .to(requestingUserIds)
                 .build();
 
         List expectedReturnDtoList = new ArrayList<>();
@@ -318,7 +320,7 @@ public class ConnectAPITest {
         MvcResult result =
             this.mockMvc
                     .perform(
-                            get("/api/connect/{userId}/all", userId)
+                            get("/api/connect/{userId}/all", toBeConnectedWithUserId)
                                     .header("Authorization", "Bearer " + auth)
                                     .characterEncoding("utf-8"))
                     .andExpect(status().isOk())

--- a/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
@@ -258,4 +258,16 @@ public class ConnectServiceImplTest extends AbstractServiceImplTest {
         assertThat(actualMessageDTOs).usingRecursiveComparison().isEqualTo(expectedOutgoingMessageDTOS);
 
     }
+
+    @Test
+    public void testGetAllConnectionsForAUserWhenConnectionsDoNotExist() {
+        Long toBeConnectedUserId = 2L;
+
+        when(connectionsRepository.findAllByToBeConnectedWithUserId(anyLong())).thenReturn(Collections.emptyList());
+
+        List<ConnectOutgoingMessageDTO> actualMessageDTOs = connectService.getAllConnectionsForAUser(toBeConnectedUserId);
+
+        assertThat(actualMessageDTOs).usingRecursiveComparison().isEqualTo(Collections.emptyList());
+
+    }
 }

--- a/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
@@ -17,10 +17,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.sql.Timestamp;
+import java.util.*;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -233,5 +231,31 @@ public class ConnectServiceImplTest extends AbstractServiceImplTest {
         doReturn(qrCodeOpt).when(connectServiceSpy).getQRCodeString(anyLong());
         Boolean isValid = connectServiceSpy.validateQRCode(providedQRCode, toBeConnectedWithUserId);
         assertTrue(isValid);
+    }
+
+    @Test
+    public void testGetAllConnectionsForAUserWhenConnectionsExist() {
+        Long toBeConnectedUserId = 2L;
+
+        Connection connection = new Connection();
+        connection.setCreated();
+        connection.setId(1L);
+        connection.setRequestingUserId(1L);
+        connection.setToBeConnectedWithUserId(toBeConnectedUserId);
+
+        when(connectionsRepository.findAllByToBeConnectedWithUserId(anyLong())).thenReturn(List.of(connection));
+
+        List<ConnectOutgoingMessageDTO> expectedOutgoingMessageDTOS = new ArrayList<>();
+        ConnectOutgoingMessageDTO outgoingMessage = ConnectOutgoingMessageDTO.builder()
+                .connectionSuccess(true)
+                .to(new ArrayList<>(Arrays.asList(connection.getRequestingUserId())))
+                .message("")
+                .build();
+        expectedOutgoingMessageDTOS.add(outgoingMessage);
+
+        List<ConnectOutgoingMessageDTO> actualMessageDTOs = connectService.getAllConnectionsForAUser(toBeConnectedUserId);
+
+        assertThat(actualMessageDTOs).usingRecursiveComparison().isEqualTo(expectedOutgoingMessageDTOS);
+
     }
 }


### PR DESCRIPTION
- updates database column naming formats for the connections table to correct SQL error at runtime
- updates Connect entity to match new naming conventions
- updates Connect API endpoint from /api/connect/all/{userId} to /api/connect/{userId}/all

Testing
- adds two tests for ConnectAPI get connections endpoint
- adds two tests for ConnectServiceImple getAllConnectionsForAUser