### PR TITLE
TRIB-232: Ensure accurate coverage reports for feature branch PRs

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,7 @@
 codecov:
   branch: develop
 coverage:
+  round: nearest
   status:
     project:
       default:
@@ -10,3 +11,6 @@ coverage:
         base: auto
         paths:
           - "src"
+parsers:
+  jacoco:
+    partials_as_hits: true

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,7 +1,6 @@
 codecov:
   branch: develop
 coverage:
-  round: nearest
   status:
     project:
       default:
@@ -11,6 +10,3 @@ coverage:
         base: auto
         paths:
           - "src"
-parsers:
-  jacoco:
-    partials_as_hits: true

--- a/.github/workflows/codecov-publish.yml
+++ b/.github/workflows/codecov-publish.yml
@@ -3,7 +3,12 @@ name: CodeCov Coverage Collection
 on:
   push:
     branches:
+      - "main"
       - "develop"
+      - "feature/connect-page"
+      - "feature/notifications-page"
+      - "feature/attributes-page"
+      - "feature/attribute-phrase-review"
 
 jobs:
   coverage:

--- a/.github/workflows/codecov-publish.yml
+++ b/.github/workflows/codecov-publish.yml
@@ -9,6 +9,8 @@ on:
       - "feature/notifications-page"
       - "feature/attributes-page"
       - "feature/attribute-phrase-review"
+      - "feature/attributes-page-temp"
+      - "feature/review-attributes-page"
 
 jobs:
   coverage:


### PR DESCRIPTION
Currently, only the "develop" branch's base coverage is uploaded to Codecov. This PR ensures Codecov also receives coverage information on the feature branches so it can check incoming PRs accurately.