### PR TITLE
TRIB-181: updates connections table column name to created

### DIFF
--- a/src/main/java/com/savvato/tribeapp/entities/Connection.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Connection.java
@@ -12,7 +12,7 @@ public class Connection {
 
     private Long requestingUserId;
     private Long toBeConnectedWithUserId;
-    private java.sql.Timestamp createdAt;
+    private java.sql.Timestamp created;
     public Long getId() {
         return id;
     }
@@ -38,11 +38,11 @@ public class Connection {
     }
 
     public java.sql.Timestamp getCreated() {
-        return createdAt;
+        return created;
     }
 
     public void setCreated() {
-        this.createdAt = java.sql.Timestamp.from(Calendar.getInstance().toInstant());
+        this.created = java.sql.Timestamp.from(Calendar.getInstance().toInstant());
     }
 
     public Connection(Long requestingUserId, Long toBeConnectedWithUserId) {

--- a/src/main/resources/db/migration/changelog-202402070939.xml
+++ b/src/main/resources/db/migration/changelog-202402070939.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="audra" id="202402070939-01">
+        <sql dbms="mysql">
+            ALTER TABLE connections RENAME COLUMN `created_at` TO created;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-master.xml
+++ b/src/main/resources/db/migration/changelog-master.xml
@@ -45,6 +45,7 @@
     <include file="changelog-202401110955.xml" relativeToChangelogFile="true"/>
     <include file="changelog-202401111012.xml" relativeToChangelogFile="true"/>
     <include file="changelog-202401291541.xml" relativeToChangelogFile="true"/>
+    <include file="changelog-202402070939.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>
 


### PR DESCRIPTION
- adds DB script to update connections table header created_at to created
- updates connection entity property from createdAt to created

Testing:
- verified all existing tests still run
- created and tested POST connect endpoint in Postman