### PR TITLE
TRIB-230: Prevent invalid connections from occurring

### DIFF
--- a/src/main/java/com/savvato/tribeapp/entities/Connection.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Connection.java
@@ -1,26 +1,23 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.*;
+
+import lombok.Generated;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
 import java.util.Calendar;
 
 @Entity
-@Table(name="connections")
+@IdClass(ConnectionId.class)
+@Table(name = "connections")
 public class Connection {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
     private Long requestingUserId;
+    @Id
     private Long toBeConnectedWithUserId;
     private java.sql.Timestamp createdTimestamp;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public Long getRequestingUserId() {
         return requestingUserId;
@@ -52,6 +49,7 @@ public class Connection {
 
         setCreated();
     }
+
     public Connection() {
 
         setCreated();

--- a/src/main/java/com/savvato/tribeapp/entities/Connection.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Connection.java
@@ -1,8 +1,6 @@
 package com.savvato.tribeapp.entities;
 
 
-import lombok.Generated;
-
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;

--- a/src/main/java/com/savvato/tribeapp/entities/ConnectionId.java
+++ b/src/main/java/com/savvato/tribeapp/entities/ConnectionId.java
@@ -1,0 +1,9 @@
+package com.savvato.tribeapp.entities;
+
+import java.io.Serializable;
+
+
+public class ConnectionId implements Serializable {
+    public Long requestingUserId;
+    public Long toBeConnectedWithUserId;
+}

--- a/src/main/java/com/savvato/tribeapp/repositories/ConnectionsRepository.java
+++ b/src/main/java/com/savvato/tribeapp/repositories/ConnectionsRepository.java
@@ -1,16 +1,21 @@
 package com.savvato.tribeapp.repositories;
 
 import com.savvato.tribeapp.entities.Connection;
-import com.savvato.tribeapp.entities.Noun;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ConnectionsRepository extends CrudRepository<Connection, Long> {
     List<Connection> findAllByToBeConnectedWithUserId(Long toBeConnectedWithUserId);
+
     @Query(nativeQuery = true, value = "delete from connections where requesting_user_id=?1 AND to_be_connected_with_user_id=?2")
     void removeConnection(Long requestingUserId, Long connectedWithUserId);
+
+    @Query(nativeQuery = true, value = "select * from connections where to_be_connected_with_user_id=?1 and requesting_user_id=?2")
+    Optional<Connection> findExistingConnectionWithReversedUserIds(Long requestingUserId, Long toBeConnectedWithUserId);
+
 }

--- a/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ConnectServiceImpl.java
@@ -6,12 +6,11 @@ import com.savvato.tribeapp.dto.ConnectOutgoingMessageDTO;
 import com.savvato.tribeapp.entities.Connection;
 import com.savvato.tribeapp.repositories.ConnectionsRepository;
 import com.savvato.tribeapp.repositories.UserRepository;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
@@ -41,7 +40,6 @@ public class ConnectServiceImpl implements ConnectService {
         String getCode = cache.get("ConnectQRCodeString", userIdToCacheKey);
         Optional<String> opt = Optional.ofNullable(getCode);
         return opt;
-
     }
 
     public Optional<String> storeQRCodeString(long userId) {
@@ -80,7 +78,7 @@ public class ConnectServiceImpl implements ConnectService {
     }
 
     public Boolean validateQRCode(String qrcodePhrase, Long toBeConnectedWithUserId) {
-        return qrcodePhrase.equals(getQRCodeString(toBeConnectedWithUserId).orElse(""));
+        return qrcodePhrase.equals(getQRCodeString(toBeConnectedWithUserId).orElse("")) && StringUtils.isNotBlank(qrcodePhrase);
     }
 
     @MessageMapping("/connect/room")

--- a/src/main/resources/db/migration/changelog-202401090508.xml
+++ b/src/main/resources/db/migration/changelog-202401090508.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="maryam" id="changelog-202401091620.xml">
+        <sql dbms="mysql">
+            ALTER TABLE connections MODIFY COLUMN id INT;
+            ALTER TABLE connections DROP PRIMARY KEY;
+            ALTER TABLE connections DROP COLUMN id;
+            ALTER TABLE connections ADD PRIMARY KEY (requesting_user_id, to_be_connected_with_user_id);
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-master.xml
+++ b/src/main/resources/db/migration/changelog-master.xml
@@ -45,6 +45,7 @@
     <include file="changelog-202311141812.xml" relativeToChangelogFile="true"/>
     <include file="changelog-202401110955.xml" relativeToChangelogFile="true"/>
     <include file="changelog-202401111012.xml" relativeToChangelogFile="true"/>
+    <include file="changelog-202401090508.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>
 

--- a/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
@@ -98,6 +98,28 @@ public class ConnectServiceImplTest extends AbstractServiceImplTest {
     }
 
     @Test
+    public void saveConnectionDetailsWhenExistingConnectionWithReversedUserIdsExists() {
+        Long requestingUserId = 1L;
+        Long toBeConnectedWithUserId = 2L;
+        Connection existingConnection = new Connection(requestingUserId, toBeConnectedWithUserId);
+        when(connectionsRepository.findExistingConnectionWithReversedUserIds(anyLong(), anyLong())).thenReturn(Optional.of(existingConnection));
+        Boolean connectionStatus = connectService.saveConnectionDetails(requestingUserId, toBeConnectedWithUserId);
+        assertEquals(connectionStatus, false);
+        verify(connectionsRepository, never()).save(any());
+    }
+
+    @Test
+    public void saveConnectionDetailsWhenIdsAreTheSame() {
+        Long requestingUserId = 2L;
+        Long toBeConnectedWithUserId = 2L;
+        Boolean connectionStatus = connectService.saveConnectionDetails(requestingUserId, toBeConnectedWithUserId);
+        assertEquals(connectionStatus, false);
+
+        verify(connectionsRepository, never()).findExistingConnectionWithReversedUserIds(anyLong(), anyLong());
+        verify(connectionsRepository, never()).save(any());
+    }
+
+    @Test
     public void connectWhenQrCodeIsInvalid() {
         UserPrincipal user = new UserPrincipal(getUser1());
         Long requestingUserId = 1L;

--- a/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
@@ -18,7 +18,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.sql.Timestamp;
 import java.util.*;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -296,7 +295,6 @@ public class ConnectServiceImplTest extends AbstractServiceImplTest {
 
         Connection connection = new Connection();
         connection.setCreated();
-        connection.setId(1L);
         connection.setRequestingUserId(1L);
         connection.setToBeConnectedWithUserId(toBeConnectedUserId);
 
@@ -305,7 +303,7 @@ public class ConnectServiceImplTest extends AbstractServiceImplTest {
         List<ConnectOutgoingMessageDTO> expectedOutgoingMessageDTOS = new ArrayList<>();
         ConnectOutgoingMessageDTO outgoingMessage = ConnectOutgoingMessageDTO.builder()
                 .connectionSuccess(true)
-                .to(new ArrayList<>(Arrays.asList(connection.getRequestingUserId())))
+                .to(new ArrayList<>(Collections.singletonList(connection.getRequestingUserId())))
                 .message("")
                 .build();
         expectedOutgoingMessageDTOS.add(outgoingMessage);

--- a/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
@@ -325,4 +325,31 @@ public class ConnectServiceImplTest extends AbstractServiceImplTest {
         assertThat(actualMessageDTOs).usingRecursiveComparison().isEqualTo(Collections.emptyList());
 
     }
+
+    @Test
+    public void validateQRCodeWhenQRCodeIsEmpty() {
+        String qrcodePhrase = "";
+        Long userId = 1L;
+        when(cacheService.get(any(), any())).thenReturn("");
+        boolean isValidQRCode = connectService.validateQRCode(qrcodePhrase, userId);
+        assertFalse(isValidQRCode);
+    }
+
+    @Test
+    public void validateQRCodeWhenQRCodeIsValid() {
+        String qrcodePhrase = "ABCDE";
+        Long userId = 1L;
+        when(cacheService.get(any(), any())).thenReturn(qrcodePhrase);
+        boolean isValidQRCode = connectService.validateQRCode(qrcodePhrase, userId);
+        assertTrue(isValidQRCode);
+    }
+
+    @Test
+    public void validateQRCodeWhenNoQRCodeIsCached() {
+        String qrcodePhrase = "ABCDE";
+        Long userId = 1L;
+        when(cacheService.get(any(), any())).thenReturn(null);
+        boolean isValidQRCode = connectService.validateQRCode(qrcodePhrase, userId);
+        assertFalse(isValidQRCode);
+    }
 }


### PR DESCRIPTION
Currently, invalid connections can be made. These include duplicate connections (either with the same IDs in the same order, or in reversed order), and circular connections (where the requesting user ID is the same as the user ID on the other end of the connection). This PR makes the following fixes:

- Duplicate connections:
 - Use a composite primary key in the Connections table consisting of the user ID columns
 - Create repository method in ConnectionsRepository to check for existing connections with reversed ID combination
- Circular connections:
 - Add check to prevent circular connection
 
Finally, as per earlier discussion, this PR also uses the Optional `ofNullable` and `orElse` methods to gracefully exit early if no corresponding QR code exists for the requesting user's ID on connection attempts (instead of throwing a 500 server error).