### PR TITLE
Exclude entities from coverage checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,7 @@
                 <configuration>
                     <excludes>
                         <exclude>com/savvato/tribeapp/TribeAppApplication.class</exclude>
+                        <exclude>com/savvato/tribeapp/entities/**</exclude>
                         <exclude>**/**/constants/**</exclude>
                     </excludes>
 


### PR DESCRIPTION
As flagged by @mrsbluerose, entities should be excluded from coverage checks since they don't contain business logic. Currently, this is causing PRs like #158 to fail.