### PR TITLE
Trib 244: bug fix users may not cosign themselves

### DIFF
--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -76,16 +76,8 @@ public class ConnectAPIController {
   @Connect
   @PostMapping
   public boolean connect(@RequestBody @Valid ConnectRequest connectRequest) {
-    if (connectService.validateQRCode(
-        connectRequest.qrcodePhrase, connectRequest.toBeConnectedWithUserId)) {
-      boolean isConnectionSaved =
-          connectService.saveConnectionDetails(
-              connectRequest.requestingUserId, connectRequest.toBeConnectedWithUserId);
-      if (isConnectionSaved) {
-        return true;
-      } else {
-        return false;
-      }
+    if (connectService.validateQRCode(connectRequest.qrcodePhrase, connectRequest.toBeConnectedWithUserId)) {
+      return connectService.saveConnectionDetails(connectRequest.requestingUserId, connectRequest.toBeConnectedWithUserId);
     } else {
       return false;
     }

--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -2,6 +2,7 @@ package com.savvato.tribeapp.controllers;
 
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.controllers.annotations.controllers.ConnectAPIController.*;
+import com.savvato.tribeapp.controllers.annotations.responses.BadRequest;
 import com.savvato.tribeapp.controllers.dto.ConnectRequest;
 import com.savvato.tribeapp.controllers.dto.CosignRequest;
 import com.savvato.tribeapp.dto.ConnectIncomingMessageDTO;
@@ -92,10 +93,13 @@ public class ConnectAPIController {
   @PostMapping("/cosign")
   public ResponseEntity<CosignDTO> saveCosign(@RequestBody @Valid CosignRequest cosignRequest) {
 
-      CosignDTO cosignDTO = cosignService.saveCosign(cosignRequest.userIdIssuing, cosignRequest.userIdReceiving, cosignRequest.phraseId);
-      
-      return ResponseEntity.status(HttpStatus.OK).body(cosignDTO);
+    Optional<CosignDTO> opt = cosignService.saveCosign(cosignRequest.userIdIssuing, cosignRequest.userIdReceiving, cosignRequest.phraseId);
 
+    if(opt.isEmpty()) {
+      log.error("Users may not cosign themselves. ");
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null);
+    }
+      return ResponseEntity.status(HttpStatus.OK).body(opt.get());
   }
   @DeleteCosign
   @DeleteMapping("/cosign")

--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -88,13 +88,16 @@ public class ConnectAPIController {
 
   @SaveCosign
   @PostMapping("/cosign")
-  public ResponseEntity<CosignDTO> saveCosign(@RequestBody @Valid CosignRequest cosignRequest) {
+  public ResponseEntity saveCosign(@RequestBody @Valid CosignRequest cosignRequest) {
 
     Optional<CosignDTO> opt = cosignService.saveCosign(cosignRequest.userIdIssuing, cosignRequest.userIdReceiving, cosignRequest.phraseId);
 
     if(opt.isEmpty()) {
       log.error("Users may not cosign themselves. ");
-      return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null);
+      GenericResponseDTO genericResponseDTO = GenericResponseDTO.builder()
+              .responseMessage("Users may not cosign themselves.")
+              .build();
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(genericResponseDTO);
     }
       return ResponseEntity.status(HttpStatus.OK).body(opt.get());
   }

--- a/src/main/java/com/savvato/tribeapp/services/CosignService.java
+++ b/src/main/java/com/savvato/tribeapp/services/CosignService.java
@@ -6,6 +6,6 @@ import java.util.Optional;
 
 public interface CosignService {
 
-    CosignDTO saveCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId);
+    Optional<CosignDTO> saveCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId);
     boolean deleteCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId);
 }

--- a/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/CosignServiceImpl.java
@@ -1,6 +1,5 @@
 package com.savvato.tribeapp.services;
 
-import com.savvato.tribeapp.controllers.dto.CosignRequest;
 import com.savvato.tribeapp.dto.CosignDTO;
 import com.savvato.tribeapp.entities.Cosign;
 import com.savvato.tribeapp.repositories.CosignRepository;
@@ -18,7 +17,11 @@ public class CosignServiceImpl implements CosignService {
     CosignRepository cosignRepository;
 
     @Override
-    public CosignDTO saveCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId) {
+    public Optional<CosignDTO> saveCosign(Long userIdIssuing, Long userIdReceiving, Long phraseId) {
+
+        if(userIdIssuing == userIdReceiving) {
+            return Optional.empty();
+        }
 
         Cosign cosign = new Cosign();
         cosign.setUserIdIssuing(userIdIssuing);
@@ -35,7 +38,7 @@ public class CosignServiceImpl implements CosignService {
                 .phraseId(savedCosign.getPhraseId())
                 .build();
 
-        return cosignDTO;
+        return Optional.of(cosignDTO);
     }
 
     @Override

--- a/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
@@ -197,6 +197,7 @@ public class ConnectAPITest {
     }
 
 
+
     @Test
     public void connectWhenQrCodeInvalid() throws Exception {
         when(userPrincipalService.getUserPrincipalByEmail(Mockito.anyString()))
@@ -233,21 +234,21 @@ public class ConnectAPITest {
                 .thenReturn(new UserPrincipal(user));
         String auth = AuthServiceImpl.generateAccessToken(user);
 
-        Long userIdIssuing = 1L;
-        Long userIdReceiving = 1L;
-        Long phraseId = 1L;
+        Long testUserIdIssuing = 1L;
+        Long testUserIdReceiving = 2L;
+        Long testPhraseId = 1L;
+
+        CosignDTO mockCosignDTO = CosignDTO.builder().build();
+        mockCosignDTO.userIdIssuing = testUserIdIssuing;
+        mockCosignDTO.userIdReceiving = testUserIdReceiving;
+        mockCosignDTO.phraseId = testPhraseId;
 
         CosignRequest cosignRequest = new CosignRequest();
-        cosignRequest.userIdIssuing = userIdIssuing;
-        cosignRequest.userIdReceiving = userIdReceiving;
-        cosignRequest.phraseId = phraseId;
+        cosignRequest.userIdIssuing = testUserIdIssuing;
+        cosignRequest.userIdReceiving = testUserIdReceiving;
+        cosignRequest.phraseId = testPhraseId;
 
-        CosignDTO cosignDTO = CosignDTO.builder().build();
-        cosignDTO.userIdIssuing = userIdIssuing;
-        cosignDTO.userIdReceiving = userIdReceiving;
-        cosignDTO.phraseId = phraseId;
-
-        when(cosignService.saveCosign(anyLong(), anyLong(), anyLong())).thenReturn(cosignDTO);
+        when(cosignService.saveCosign(anyLong(), anyLong(), anyLong())).thenReturn(Optional.of(mockCosignDTO));
 
         this.mockMvc
                 .perform(
@@ -257,8 +258,35 @@ public class ConnectAPITest {
                                 .header("Authorization", "Bearer " + auth)
                                 .characterEncoding("utf-8"))
                 .andExpect(status().isOk())
-                .andExpect(content().json("{\"userIdIssuing\":1,\"userIdReceiving\":1,\"phraseId\":1}"));
+                .andExpect(content().json("{\"userIdIssuing\":1,\"userIdReceiving\":2,\"phraseId\":1}"));
 
+    }
+
+    @Test
+    public void saveCosignSadPathUserCosignsThemselves() throws Exception {
+        when(userPrincipalService.getUserPrincipalByEmail(Mockito.anyString()))
+                .thenReturn(new UserPrincipal(user));
+        String auth = AuthServiceImpl.generateAccessToken(user);
+
+        Long testUserIdIssuing = 1L;
+        Long testUserIdReceiving = 1L;
+        Long testPhraseId = 1L;
+
+        CosignRequest cosignRequest = new CosignRequest();
+        cosignRequest.userIdIssuing = testUserIdIssuing;
+        cosignRequest.userIdReceiving = testUserIdReceiving;
+        cosignRequest.phraseId = testPhraseId;
+
+        when(cosignService.saveCosign(anyLong(), anyLong(), anyLong())).thenReturn(Optional.empty());
+
+        this.mockMvc
+                .perform(
+                        post("/api/connect/cosign")
+                                .content(gson.toJson(cosignRequest))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer " + auth)
+                                .characterEncoding("utf-8"))
+                .andExpect(status().isForbidden());
     }
 
     public void removeConnectionHappyPath() throws Exception {

--- a/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
@@ -171,6 +171,33 @@ public class ConnectAPITest {
     }
 
     @Test
+    public void connectSadPath() throws Exception {
+        when(userPrincipalService.getUserPrincipalByEmail(Mockito.anyString()))
+                .thenReturn(new UserPrincipal(user));
+        String auth = AuthServiceImpl.generateAccessToken(user);
+        ConnectRequest connectRequest = new ConnectRequest();
+
+        connectRequest.requestingUserId = 1L;
+        connectRequest.toBeConnectedWithUserId = 2L;
+        connectRequest.qrcodePhrase = "ABCDEFGHIJKL";
+
+        when(connectService.validateQRCode(anyString(), anyLong())).thenReturn(true);
+        when(connectService.saveConnectionDetails(anyLong(), anyLong())).thenReturn(false);
+        this.mockMvc
+                .perform(
+                        post("/api/connect")
+                                .content(gson.toJson(connectRequest))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header("Authorization", "Bearer " + auth)
+                                .characterEncoding("utf-8"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("false"))
+                .andReturn();
+
+    }
+
+
+    @Test
     public void connectWhenQrCodeInvalid() throws Exception {
         when(userPrincipalService.getUserPrincipalByEmail(Mockito.anyString()))
                 .thenReturn(new UserPrincipal(user));

--- a/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
@@ -288,7 +288,8 @@ public class ConnectAPITest {
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header("Authorization", "Bearer " + auth)
                                 .characterEncoding("utf-8"))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json("{\"responseMessage\":\"Users may not cosign themselves.\"}"));
     }
 
     public void removeConnectionHappyPath() throws Exception {

--- a/src/test/java/com/savvato/tribeapp/services/CosignServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/CosignServiceImplTest.java
@@ -12,7 +12,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.Optional;
+
 import static net.bytebuddy.matcher.ElementMatchers.any;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
@@ -38,57 +41,51 @@ public class CosignServiceImplTest extends AbstractServiceImplTest{
     @Test
     public void saveCosign() {
         Long userIdIssuing = 1L;
-        Long userIdReceiving = 1L;
+        Long userIdReceiving = 2L;
         Long phraseId = 1L;
 
-        Cosign cosign = new Cosign();
-        cosign.setUserIdIssuing(userIdIssuing);
-        cosign.setUserIdReceiving(userIdReceiving);
-        cosign.setPhraseId(phraseId);
+        Cosign mockCosign = new Cosign();
+        mockCosign.setUserIdIssuing(userIdIssuing);
+        mockCosign.setUserIdReceiving(userIdReceiving);
+        mockCosign.setPhraseId(phraseId);
 
-        CosignDTO cosignDTO = CosignDTO.builder().build();
-        cosignDTO.userIdIssuing = userIdIssuing;
-        cosignDTO.userIdReceiving = userIdReceiving;
-        cosignDTO.phraseId = phraseId;
+        CosignDTO expectedCosignDTO = CosignDTO.builder().build();
+        expectedCosignDTO.userIdIssuing = userIdIssuing;
+        expectedCosignDTO.userIdReceiving = userIdReceiving;
+        expectedCosignDTO.phraseId = phraseId;
 
-        when(cosignRepository.save(Mockito.any())).thenReturn(cosign);
+        when(cosignRepository.save(Mockito.any())).thenReturn(mockCosign);
 
-        CosignDTO expectedCosignDTO = cosignService.saveCosign(userIdIssuing, userIdReceiving, phraseId);
+        Optional<CosignDTO> CosignDTO = cosignService.saveCosign(userIdIssuing, userIdReceiving, phraseId);
 
         verify(cosignRepository, times(1)).save(Mockito.any());
-        assertEquals(cosignDTO.userIdIssuing, expectedCosignDTO.userIdIssuing);
-        assertEquals(cosignDTO.userIdReceiving, expectedCosignDTO.userIdReceiving);
-        assertEquals(cosignDTO.phraseId, expectedCosignDTO.phraseId);
+        assertThat(CosignDTO.get()).usingRecursiveComparison().isEqualTo(expectedCosignDTO);
     }
 
     @Test
     public void saveCosignAlreadyExisting() {
         Long userIdIssuing = 1L;
-        Long userIdReceiving = 1L;
+        Long userIdReceiving = 2L;
         Long phraseId = 1L;
 
-        Cosign cosign = new Cosign();
-        cosign.setUserIdIssuing(userIdIssuing);
-        cosign.setUserIdReceiving(userIdReceiving);
-        cosign.setPhraseId(phraseId);
+        Cosign mockCosign = new Cosign();
+        mockCosign.setUserIdIssuing(userIdIssuing);
+        mockCosign.setUserIdReceiving(userIdReceiving);
+        mockCosign.setPhraseId(phraseId);
 
-        CosignDTO cosignDTO = CosignDTO.builder().build();
-        cosignDTO.userIdIssuing = userIdIssuing;
-        cosignDTO.userIdReceiving = userIdReceiving;
-        cosignDTO.phraseId = phraseId;
+        CosignDTO expectedCosignDTO = CosignDTO.builder().build();
+        expectedCosignDTO.userIdIssuing = userIdIssuing;
+        expectedCosignDTO.userIdReceiving = userIdReceiving;
+        expectedCosignDTO.phraseId = phraseId;
 
-        when(cosignRepository.save(Mockito.any())).thenReturn(cosign).thenReturn(cosign);
+        when(cosignRepository.save(Mockito.any())).thenReturn(mockCosign).thenReturn(mockCosign);
 
-        CosignDTO expectedCosignDTO = cosignService.saveCosign(userIdIssuing, userIdReceiving, phraseId);
+        Optional<CosignDTO> CosignDTO = cosignService.saveCosign(userIdIssuing, userIdReceiving, phraseId);
 
-        assertEquals(cosignDTO.userIdIssuing, expectedCosignDTO.userIdIssuing);
-        assertEquals(cosignDTO.userIdReceiving, expectedCosignDTO.userIdReceiving);
-        assertEquals(cosignDTO.phraseId, expectedCosignDTO.phraseId);
+        assertThat(CosignDTO.get()).usingRecursiveComparison().isEqualTo(expectedCosignDTO);
 
-        CosignDTO expectedCosignDTORepeat = cosignService.saveCosign(userIdIssuing, userIdReceiving, phraseId);
+        Optional<CosignDTO> CosignDTORepeat = cosignService.saveCosign(userIdIssuing, userIdReceiving, phraseId);
 
-        assertEquals(cosignDTO.userIdIssuing, expectedCosignDTORepeat.userIdIssuing);
-        assertEquals(cosignDTO.userIdReceiving, expectedCosignDTORepeat.userIdReceiving);
-        assertEquals(cosignDTO.phraseId, expectedCosignDTORepeat.phraseId);
+        assertThat(CosignDTORepeat.get()).usingRecursiveComparison().isEqualTo(expectedCosignDTO);
     }
 }

--- a/src/test/java/com/savvato/tribeapp/services/CosignServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/CosignServiceImplTest.java
@@ -88,4 +88,16 @@ public class CosignServiceImplTest extends AbstractServiceImplTest{
 
         assertThat(CosignDTORepeat.get()).usingRecursiveComparison().isEqualTo(expectedCosignDTO);
     }
+
+    @Test
+    public void saveCosignFailsWhenIdsEqual() {
+        Long testUserIdIssuing = 1L;
+        Long testUserIdReceiving = 1L;
+        Long testPhraseId = 1L;
+
+        Optional<CosignDTO> cosignDTO = cosignService.saveCosign(testUserIdIssuing, testUserIdReceiving, testPhraseId);
+
+        verify(cosignRepository, never()).save(Mockito.any());
+        assertThat(cosignDTO).usingRecursiveComparison().isEqualTo(Optional.empty());
+    }
 }


### PR DESCRIPTION
- updates cosign service saveCosign() return type to Optional<CosignDTO>
- updates Connect API call to cosign service saveCosign() to Optional<CosignDTO>
- adds Connect API return for bad request 403 forbidden

TESTING
Cosign service and Connect API
- updates variable names for clarity (test, mock, expected)
- updates return values to the new Optional<CosignDTO> change
- simplifies assertions with recursive comparison method
- corrects testing values for save cosign happy path to be different ids
- adds save cosign sad path for when IDs are the same

QUESTIONS:
This ticket is a stab in the dark. Please let me know if you want changes to the return values for the ConnectAPI save cosign endpoint.