### PR TITLE
Add CodeCov token, remove duplicate Github coverage actions

### DIFF
--- a/.github/workflows/codecov-publish.yml
+++ b/.github/workflows/codecov-publish.yml
@@ -32,4 +32,6 @@ jobs:
       - name: Run tests and collect coverage
         run: mvn -B test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -24,10 +24,6 @@ jobs:
           settings-path: ${{ github.workspace }} # location for the settings.xml file
       - name: Install dependencies
         run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-      - name: Run tests and collect coverage
-        run: mvn -B test
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
 
 #    - name: Publish to GitHub Packages Apache Maven
 #      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml


### PR DESCRIPTION
This PR adds the CodeCov token and removes the duplicate GitHub coverage collection & upload actions found in `maven-publish.yml`. (The same actions exist in `codecov-publish.yml` already).