### PR TITLE
TRIB-261: Ensure coverage is uploaded on pull requests as well.

### DIFF
--- a/.github/workflows/codecov-publish.yml
+++ b/.github/workflows/codecov-publish.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - "main"
       - "develop"
-      - "feature/connect-page"
-      - "feature/notifications-page"
-      - "feature/attributes-page"
-      - "feature/attribute-phrase-review"
-      - "feature/attributes-page-temp"
-      - "feature/review-attributes-page"
+      - "feature/*"
+  pull_request:
+    branches:
+      - "main"
+      - "develop"
+      - "feature/*"
 
 jobs:
   coverage:

--- a/.github/workflows/codecov-publish.yml
+++ b/.github/workflows/codecov-publish.yml
@@ -32,4 +32,6 @@ jobs:
       - name: Run tests and collect coverage
         run: mvn -B test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -24,10 +24,6 @@ jobs:
           settings-path: ${{ github.workspace }} # location for the settings.xml file
       - name: Install dependencies
         run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-      - name: Run tests and collect coverage
-        run: mvn -B test
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
 
 #    - name: Publish to GitHub Packages Apache Maven
 #      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml


### PR DESCRIPTION
Currently, coverage is being uploaded _after_ the pull request has been merged. This is important because it allows the branch's existing coverage to be compared against the incoming PR's coverage. However, coverage also needs to be uploaded upon the creation of a pull request, so that insufficient coverage can be flagged and PRs with low coverage can be blocked.