### PR TITLE
Upgrading Java 18/19 to 22, Spring 2.2.5 to 3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.5</version>
+        <version>3.3.1</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.savvato</groupId>
@@ -14,9 +14,9 @@
     <name>tribeapp</name>
     <description>A social network that helps you find your tribe.</description>
     <properties>
-        <java.version>19</java.version>
-        <maven.compiler.source>19</maven.compiler.source>
-        <maven.compiler.target>19</maven.compiler.target>
+        <java.version>22</java.version>
+        <maven.compiler.source>22</maven.compiler.source>
+        <maven.compiler.target>22</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.32</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -54,18 +54,14 @@
             <artifactId>liquibase-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-            <version>4.4</version>
-        </dependency>
-        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt</artifactId>
             <version>0.9.1</version>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.4.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -76,17 +72,14 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-resource-server</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.springframework/spring-websocket -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-websocket</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.springframework/spring-messaging -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-messaging</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.springframework/spring-web -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
@@ -110,28 +103,28 @@
         <dependency>
             <groupId>com.plivo</groupId>
             <artifactId>plivo-java</artifactId>
-            <version>5.9.3</version>
+            <version>5.43.1</version>
         </dependency>
         <dependency>
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
-            <version>3.4.0</version>
+            <version>3.10.8</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.9.1</version>
+            <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.8</version>
+            <version>0.8.12</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.10.1</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
@@ -141,7 +134,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-security</artifactId>
-            <version>1.7.0</version>
+            <version>1.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>
@@ -180,7 +173,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
+                <version>0.8.12</version>
                 <configuration>
                     <excludes>
                         <exclude>com/savvato/tribeapp/TribeAppApplication.class</exclude>
@@ -207,7 +200,7 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>1.5.8</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>generate-docs</id>
@@ -233,11 +226,18 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>22</source>
+                    <target>22</target>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <repository>
+            <id>maven_central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2/</url>
+        </repository>
+    </repositories>
 
 </project>

--- a/src/main/java/com/savvato/tribeapp/config/RestTemplateConfig.java
+++ b/src/main/java/com/savvato/tribeapp/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.savvato.tribeapp.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/com/savvato/tribeapp/config/SecurityConfig.java
+++ b/src/main/java/com/savvato/tribeapp/config/SecurityConfig.java
@@ -2,7 +2,7 @@ package com.savvato.tribeapp.config;
 
 import java.util.Arrays;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.savvato.tribeapp.config.filters.JwtTokenFilter;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
@@ -12,14 +12,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -33,66 +34,73 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
         bearerFormat = "JWT",
         scheme = "bearer"
 )
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
     private final UserDetailsService userDetailsService;
-    
     private final JwtTokenFilter jwtTokenFilter;
 
-    @Autowired
     public SecurityConfig(UserDetailsService userDetailsService, JwtTokenFilter jwtTokenFilter) {
         this.userDetailsService = userDetailsService;
         this.jwtTokenFilter = jwtTokenFilter;
     }
 
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder());
+    @Bean
+    public DaoAuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
     }
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-
-        // Enable CORS and disable CSRF
-    	http = http.cors().and().csrf().disable();
-    	
-    	// Set session management to stateless
-    	http = http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and();
-    	
-    	// Set unauthorized requests exception handler
-    	http = http.exceptionHandling()
-    			.authenticationEntryPoint(
-    				(request, response, ex) -> {
-    					response.sendError(HttpServletResponse.SC_UNAUTHORIZED, ex.getMessage());
-    				}
-    			).and();
-    	// Set permissions on endpoints
-    	http.authorizeRequests()
-        .antMatchers(HttpMethod.HEAD, "/api/resource/topic/*").permitAll()  // this is because of the saveAs extension we use on the front end.. it won't let us pass in headers, so no authorization can be had.. ASAP, find a better way.
-        .antMatchers(HttpMethod.GET, "/api/resource/topic/*").permitAll()  // this is because of the saveAs extension we use on the front end.. it won't let us pass in headers, so no authorization can be had.. ASAP, find a better way.
-    	.antMatchers(HttpMethod.POST, "/api/public/login").permitAll()
-    	.antMatchers(HttpMethod.POST, "/api/public/user/new").permitAll()
-        .antMatchers(HttpMethod.GET, "/api/public/user/isEmailAddressAvailable").permitAll()
-        .antMatchers(HttpMethod.GET, "/api/public/user/isPhoneNumberAvailable").permitAll()
-        .antMatchers(HttpMethod.GET, "/api/public/user/isUsernameAvailable").permitAll()
-        .antMatchers(HttpMethod.POST, "/api/public/user/changeLostPassword").permitAll()
-        .antMatchers(HttpMethod.GET, "/api/public/user/isUserInformationUnique").permitAll()
-        .antMatchers(HttpMethod.POST, "/api/public/sendSMSChallengeCodeToPhoneNumber").permitAll()
-        .antMatchers(HttpMethod.POST, "/api/public/isAValidSMSChallengeCode").permitAll()
-        .antMatchers("/swagger-ui/**", "/swagger-ui**", "/docs/**", "/docs**").permitAll()
-    	.anyRequest().hasAnyRole("admin,accountholder");
-
-    	
-    	// Add JWT token filter
-    	http.addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class);
-    }
-    
-    //====================encoders
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder authBuilder = http.getSharedObject(AuthenticationManagerBuilder.class);
+        authBuilder.authenticationProvider(authenticationProvider());
+        return authBuilder.build();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        // Enable CORS using the new method
+        http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                // Disable CSRF using the new method
+                .csrf(csrf -> csrf.disable())
+                // Set session management to stateless
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // Set unauthorized requests exception handler
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, ex) -> {
+                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, ex.getMessage());
+                        }))
+                // Set permissions on endpoints
+                .authorizeHttpRequests(authorizeRequests ->
+                        authorizeRequests
+                                .requestMatchers(HttpMethod.HEAD,   "/api/resource/topic/*").permitAll()
+                                .requestMatchers(HttpMethod.GET,    "/api/resource/topic/*").permitAll()
+                                .requestMatchers(HttpMethod.POST,   "/api/public/login").permitAll()
+                                .requestMatchers(HttpMethod.POST,   "/api/public/user/new").permitAll()
+                                .requestMatchers(HttpMethod.GET,    "/api/public/user/isEmailAddressAvailable").permitAll()
+                                .requestMatchers(HttpMethod.GET,    "/api/public/user/isPhoneNumberAvailable").permitAll()
+                                .requestMatchers(HttpMethod.GET,    "/api/public/user/isUsernameAvailable").permitAll()
+                                .requestMatchers(HttpMethod.POST,   "/api/public/user/changeLostPassword").permitAll()
+                                .requestMatchers(HttpMethod.GET,    "/api/public/user/isUserInformationUnique").permitAll()
+                                .requestMatchers(HttpMethod.POST,   "/api/public/sendSMSChallengeCodeToPhoneNumber").permitAll()
+                                .requestMatchers(HttpMethod.POST,   "/api/public/isAValidSMSChallengeCode").permitAll()
+                                .requestMatchers("/swagger-ui/**", "/swagger-ui**", "/docs/**", "/docs**").permitAll()
+                                .anyRequest().hasAnyRole("admin", "accountholder")
+                );
+
+        // Add JWT token filter
+        http.addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+    
     //===================CORS
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
@@ -104,11 +112,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
-    }
-
-    @Override @Bean
-    public AuthenticationManager authenticationManagerBean() throws Exception {
-        return super.authenticationManagerBean();
     }
 
 }

--- a/src/main/java/com/savvato/tribeapp/config/filters/JwtTokenFilter.java
+++ b/src/main/java/com/savvato/tribeapp/config/filters/JwtTokenFilter.java
@@ -3,10 +3,10 @@ package com.savvato.tribeapp.config.filters;
 import java.io.IOException;
 import java.util.List;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.services.UserPrincipalService;

--- a/src/main/java/com/savvato/tribeapp/config/principal/UserPrincipal.java
+++ b/src/main/java/com/savvato/tribeapp/config/principal/UserPrincipal.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Set;
 
 import com.savvato.tribeapp.entities.UserRole;
-import org.apache.commons.collections4.CollectionUtils;
 import com.savvato.tribeapp.entities.User;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -26,7 +25,7 @@ public class UserPrincipal implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         final Set<UserRole> roles = user != null ? user.getRoles() : null;
         final List<GrantedAuthority> authorities = new ArrayList<>();
-        if (CollectionUtils.isNotEmpty(roles)) {
+        if (roles != null && !roles.isEmpty()) {
             roles.forEach(role -> {
                 if (role != null) {
 //                	System.out.println("User has role [" + role.getName() + "]");

--- a/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
@@ -17,7 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Optional;
 
@@ -49,7 +49,6 @@ public class AttributesAPIController {
     AttributesAPIController() {
     }
 
-
     @GetAttributesForUser
     @GetMapping("/{userId}")
     public ResponseEntity<List<AttributeDTO>> getAttributesForUser(
@@ -69,6 +68,7 @@ public class AttributesAPIController {
         List<ToBeReviewedDTO> rtn = reviewSubmittingUserService.getUserPhrasesToBeReviewed(userId);
         return ResponseEntity.status(HttpStatus.OK).body(rtn);
     }
+
     @ApplyPhraseToUser
     @PostMapping
     public ResponseEntity<GenericResponseDTO> applyPhraseToUser(@RequestBody @Valid AttributesRequest req) {

--- a/src/main/java/com/savvato/tribeapp/controllers/AuthAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/AuthAPIController.java
@@ -6,7 +6,7 @@ import com.savvato.tribeapp.controllers.dto.AuthRequest;
 import com.savvato.tribeapp.entities.User;
 import com.savvato.tribeapp.services.AuthServiceImpl;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;

--- a/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ConnectAPIController.java
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/savvato/tribeapp/controllers/FileUploadController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/FileUploadController.java
@@ -10,7 +10,7 @@ import com.savvato.tribeapp.services.StorageService;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;

--- a/src/main/java/com/savvato/tribeapp/controllers/NotificationAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/NotificationAPIController.java
@@ -10,7 +10,7 @@ import com.savvato.tribeapp.services.NotificationService;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/savvato/tribeapp/controllers/PermissionsAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/PermissionsAPIController.java
@@ -10,7 +10,7 @@ import com.savvato.tribeapp.services.UserRoleMapService;
 import com.savvato.tribeapp.services.UserRoleService;
 import com.savvato.tribeapp.services.UserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/savvato/tribeapp/controllers/ProfileAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ProfileAPIController.java
@@ -14,7 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.Optional;
 
 @RestController

--- a/src/main/java/com/savvato/tribeapp/controllers/ReviewDecisionAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/ReviewDecisionAPIController.java
@@ -6,7 +6,7 @@ import com.savvato.tribeapp.dto.ReviewDecisionDTO;
 import com.savvato.tribeapp.entities.ReviewDecision;
 import com.savvato.tribeapp.services.ReviewDecisionService;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/savvato/tribeapp/controllers/SMSChallengeCodeAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/SMSChallengeCodeAPIController.java
@@ -11,8 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/public")

--- a/src/main/java/com/savvato/tribeapp/controllers/UserAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/UserAPIController.java
@@ -14,7 +14,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.Optional;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/savvato/tribeapp/entities/Adverb.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Adverb.java
@@ -1,6 +1,6 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name="adverb")

--- a/src/main/java/com/savvato/tribeapp/entities/Connection.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Connection.java
@@ -1,10 +1,10 @@
 package com.savvato.tribeapp.entities;
 
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.IdClass;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
 import java.util.Calendar;
 
 @Entity

--- a/src/main/java/com/savvato/tribeapp/entities/Cosign.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Cosign.java
@@ -1,8 +1,8 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.IdClass;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
 
 @Entity
 @IdClass(CosignId.class)

--- a/src/main/java/com/savvato/tribeapp/entities/Notification.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Notification.java
@@ -1,6 +1,6 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/java/com/savvato/tribeapp/entities/NotificationType.java
+++ b/src/main/java/com/savvato/tribeapp/entities/NotificationType.java
@@ -1,6 +1,6 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name = "notification_type")

--- a/src/main/java/com/savvato/tribeapp/entities/Noun.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Noun.java
@@ -1,6 +1,6 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name="noun")

--- a/src/main/java/com/savvato/tribeapp/entities/Phrase.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Phrase.java
@@ -3,7 +3,7 @@ package com.savvato.tribeapp.entities;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.List;
 
 @Entity

--- a/src/main/java/com/savvato/tribeapp/entities/Preposition.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Preposition.java
@@ -1,6 +1,6 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name="preposition")

--- a/src/main/java/com/savvato/tribeapp/entities/Profile.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Profile.java
@@ -2,10 +2,10 @@ package com.savvato.tribeapp.entities;
 
 import java.util.Calendar;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 @Entity
 public class Profile {

--- a/src/main/java/com/savvato/tribeapp/entities/RejectedNonEnglishWord.java
+++ b/src/main/java/com/savvato/tribeapp/entities/RejectedNonEnglishWord.java
@@ -1,6 +1,6 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name="rejected_non_english_word")

--- a/src/main/java/com/savvato/tribeapp/entities/RejectedPhrase.java
+++ b/src/main/java/com/savvato/tribeapp/entities/RejectedPhrase.java
@@ -1,9 +1,9 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 @Entity
 public class RejectedPhrase {

--- a/src/main/java/com/savvato/tribeapp/entities/ReviewDecision.java
+++ b/src/main/java/com/savvato/tribeapp/entities/ReviewDecision.java
@@ -1,6 +1,6 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Calendar;
 
 @Entity

--- a/src/main/java/com/savvato/tribeapp/entities/ReviewDecisionReason.java
+++ b/src/main/java/com/savvato/tribeapp/entities/ReviewDecisionReason.java
@@ -1,6 +1,6 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name="review_decision_reason")

--- a/src/main/java/com/savvato/tribeapp/entities/ReviewSubmittingUser.java
+++ b/src/main/java/com/savvato/tribeapp/entities/ReviewSubmittingUser.java
@@ -1,8 +1,8 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.IdClass;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
 
 @Entity
 @IdClass(ReviewSubmittingUserId.class)

--- a/src/main/java/com/savvato/tribeapp/entities/ToBeReviewed.java
+++ b/src/main/java/com/savvato/tribeapp/entities/ToBeReviewed.java
@@ -1,6 +1,6 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name="to_be_reviewed")

--- a/src/main/java/com/savvato/tribeapp/entities/User.java
+++ b/src/main/java/com/savvato/tribeapp/entities/User.java
@@ -3,14 +3,14 @@ package com.savvato.tribeapp.entities;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Calendar;
 import java.util.Set;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 
 @Schema(description = "A user")
 @Entity

--- a/src/main/java/com/savvato/tribeapp/entities/UserPhrase.java
+++ b/src/main/java/com/savvato/tribeapp/entities/UserPhrase.java
@@ -1,8 +1,8 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.IdClass;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
 
 @Entity
 @IdClass(UserPhraseId.class)

--- a/src/main/java/com/savvato/tribeapp/entities/UserRole.java
+++ b/src/main/java/com/savvato/tribeapp/entities/UserRole.java
@@ -2,10 +2,10 @@ package com.savvato.tribeapp.entities;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 
 @Schema(description= "A user's role")
 @Entity

--- a/src/main/java/com/savvato/tribeapp/entities/UserRoleMap.java
+++ b/src/main/java/com/savvato/tribeapp/entities/UserRoleMap.java
@@ -1,9 +1,9 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.IdClass;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
 
 @Entity
 @IdClass(UserRoleMapId.class)

--- a/src/main/java/com/savvato/tribeapp/entities/Verb.java
+++ b/src/main/java/com/savvato/tribeapp/entities/Verb.java
@@ -1,6 +1,6 @@
 package com.savvato.tribeapp.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name="verb")

--- a/src/main/java/com/savvato/tribeapp/repositories/ReviewSubmittingUserRepository.java
+++ b/src/main/java/com/savvato/tribeapp/repositories/ReviewSubmittingUserRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
-import javax.persistence.IdClass;
+import jakarta.persistence.IdClass;
 import java.util.List;
 
 @Repository

--- a/src/main/java/com/savvato/tribeapp/services/ToBeReviewedCheckerServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/ToBeReviewedCheckerServiceImpl.java
@@ -43,14 +43,9 @@ public class ToBeReviewedCheckerServiceImpl implements ToBeReviewedCheckerServic
 
     @Autowired
     RestTemplate restTemplate;
+
     @Value("${WORDS_API_KEY}")
     private String apiKey;
-
-    @Generated
-    @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder builder) {
-        return builder.build();
-    }
 
     @Scheduled(fixedDelayString = "PT10M")
     @Override

--- a/src/test/java/com/savvato/tribeapp/controllers/AttributesAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/AttributesAPITest.java
@@ -2,6 +2,7 @@ package com.savvato.tribeapp.controllers;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.savvato.tribeapp.config.SecurityConfig;
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.PhraseTestConstants;
 import com.savvato.tribeapp.constants.UserTestConstants;
@@ -12,7 +13,6 @@ import com.savvato.tribeapp.dto.ToBeReviewedDTO;
 import com.savvato.tribeapp.dto.GenericResponseDTO;
 import com.savvato.tribeapp.entities.NotificationType;
 import com.savvato.tribeapp.entities.User;
-import com.savvato.tribeapp.entities.UserRole;
 import com.savvato.tribeapp.services.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,6 +21,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -39,6 +40,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AttributesAPIController.class)
+@Import(SecurityConfig.class)
 public class AttributesAPITest implements UserTestConstants, PhraseTestConstants {
     private UserPrincipal userPrincipal;
     private User user;
@@ -386,9 +388,9 @@ public class AttributesAPITest implements UserTestConstants, PhraseTestConstants
     @Test
     public void getUserPhrasesToBeReviewedHappyPathNoPhrases() throws Exception {
         Mockito.when(userPrincipalService.getUserPrincipalByEmail(Mockito.anyString()))
-                .thenReturn(new UserPrincipal(user));
-        String auth = AuthServiceImpl.generateAccessToken(user);
-        Long userId = USER1_ID;
+                .thenReturn(new UserPrincipal(UserTestConstants.getUser3()));
+        String auth = AuthServiceImpl.generateAccessToken(UserTestConstants.getUser3());
+        Long userId = USER3_ID;
 
         when(reviewSubmittingUserService.getUserPhrasesToBeReviewed(anyLong())).thenReturn(new ArrayList<>());
 

--- a/src/test/java/com/savvato/tribeapp/controllers/AuthAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/AuthAPITest.java
@@ -2,6 +2,7 @@ package com.savvato.tribeapp.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
+import com.savvato.tribeapp.config.SecurityConfig;
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.controllers.dto.AuthRequest;
@@ -15,6 +16,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -35,7 +37,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AuthAPIController.class)
-
+@Import(SecurityConfig.class)
 public class AuthAPITest {
 
     @Autowired

--- a/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ConnectAPITest.java
@@ -2,6 +2,7 @@ package com.savvato.tribeapp.controllers;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.savvato.tribeapp.config.SecurityConfig;
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.PhraseTestConstants;
 import com.savvato.tribeapp.constants.UserTestConstants;
@@ -20,6 +21,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -40,6 +42,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ConnectAPIController.class)
+@Import(SecurityConfig.class)
 public class ConnectAPITest implements UserTestConstants, PhraseTestConstants {
     private User user;
     @Autowired

--- a/src/test/java/com/savvato/tribeapp/controllers/NotificationAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/NotificationAPITest.java
@@ -3,6 +3,7 @@ package com.savvato.tribeapp.controllers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.savvato.tribeapp.config.SecurityConfig;
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.constants.UserTestConstants;
@@ -21,6 +22,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -44,6 +46,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(NotificationAPIController.class)
+@Import(SecurityConfig.class)
 public class NotificationAPITest implements UserTestConstants {
     private UserPrincipal userPrincipal;
     private User user;

--- a/src/test/java/com/savvato/tribeapp/controllers/PermissionsAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/PermissionsAPITest.java
@@ -2,6 +2,7 @@ package com.savvato.tribeapp.controllers;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.savvato.tribeapp.config.SecurityConfig;
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.controllers.dto.PermissionsRequest;
@@ -19,6 +20,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -40,6 +42,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(PermissionsAPIController.class)
+@Import(SecurityConfig.class)
 public class PermissionsAPITest {
     private UserPrincipal userPrincipal;
     private User user;

--- a/src/test/java/com/savvato/tribeapp/controllers/ProfileAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ProfileAPITest.java
@@ -1,5 +1,6 @@
 package com.savvato.tribeapp.controllers;
 
+import com.savvato.tribeapp.config.SecurityConfig;
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.dto.ProfileDTO;
@@ -14,6 +15,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
@@ -37,6 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProfileAPIController.class)
+@Import(SecurityConfig.class)
 public class ProfileAPITest {
 
     @Autowired

--- a/src/test/java/com/savvato/tribeapp/controllers/ReviewDecisionAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ReviewDecisionAPITest.java
@@ -1,5 +1,6 @@
 package com.savvato.tribeapp.controllers;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.savvato.tribeapp.config.SecurityConfig;
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.UserTestConstants;
 import com.savvato.tribeapp.controllers.dto.ReviewDecisionRequest;
@@ -14,6 +15,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -30,6 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ReviewDecisionAPIController.class)
+@Import(SecurityConfig.class)
 public class ReviewDecisionAPITest implements UserTestConstants {
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/savvato/tribeapp/controllers/ReviewDecisionReasonAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ReviewDecisionReasonAPITest.java
@@ -1,6 +1,7 @@
 package com.savvato.tribeapp.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.savvato.tribeapp.config.SecurityConfig;
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.UserTestConstants;
 import com.savvato.tribeapp.dto.ReviewDecisionReasonDTO;
@@ -13,6 +14,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -24,6 +26,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ReviewDecisionReasonAPIController.class)
+@Import(SecurityConfig.class)
 public class ReviewDecisionReasonAPITest implements UserTestConstants {
 
     @Autowired

--- a/src/test/java/com/savvato/tribeapp/controllers/SMSChallengeCodeAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/SMSChallengeCodeAPITest.java
@@ -1,6 +1,7 @@
 package com.savvato.tribeapp.controllers;
 
 import com.google.gson.Gson;
+import com.savvato.tribeapp.config.SecurityConfig;
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.controllers.dto.SMSChallengeRequest;
@@ -19,6 +20,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -37,6 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(SMSChallengeCodeAPIController.class)
+@Import(SecurityConfig.class)
 public class SMSChallengeCodeAPITest {
     private User user;
     @Autowired

--- a/src/test/java/com/savvato/tribeapp/controllers/ToBeReviewedAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/ToBeReviewedAPITest.java
@@ -2,6 +2,7 @@ package com.savvato.tribeapp.controllers;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.savvato.tribeapp.config.SecurityConfig;
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.PhraseTestConstants;
 import com.savvato.tribeapp.constants.UserTestConstants;
@@ -18,6 +19,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -35,6 +37,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ToBeReviewedAPIController.class)
+@Import(SecurityConfig.class)
 public class ToBeReviewedAPITest implements UserTestConstants, PhraseTestConstants {
 
   private UserPrincipal userPrincipal;

--- a/src/test/java/com/savvato/tribeapp/controllers/UserAPITest.java
+++ b/src/test/java/com/savvato/tribeapp/controllers/UserAPITest.java
@@ -3,6 +3,7 @@ package com.savvato.tribeapp.controllers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.savvato.tribeapp.config.SecurityConfig;
 import com.savvato.tribeapp.config.principal.UserPrincipal;
 import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.controllers.dto.ChangePasswordRequest;
@@ -21,6 +22,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -42,6 +44,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(UserAPIController.class)
+@Import(SecurityConfig.class)
 public class UserAPITest {
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/ConnectServiceImplTest.java
@@ -1,28 +1,28 @@
 package com.savvato.tribeapp.services;
 
-import com.savvato.tribeapp.config.principal.UserPrincipal;
-import com.savvato.tribeapp.constants.PhraseTestConstants;
+import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.constants.UserTestConstants;
-import com.savvato.tribeapp.controllers.dto.ConnectionRemovalRequest;
 import com.savvato.tribeapp.dto.ConnectOutgoingMessageDTO;
 import com.savvato.tribeapp.dto.GenericResponseDTO;
 import com.savvato.tribeapp.dto.UsernameConnectionStatusDTO;
 import com.savvato.tribeapp.entities.Connection;
 import com.savvato.tribeapp.repositories.ConnectionsRepository;
 import com.savvato.tribeapp.repositories.UserRepository;
-import liquibase.pro.packaged.U;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import com.savvato.tribeapp.constants.Constants;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/savvato/tribeapp/services/UserServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/services/UserServiceImplTest.java
@@ -31,9 +31,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Matchers.any;
+//import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
@@ -327,7 +326,7 @@ public class UserServiceImplTest extends AbstractTestConstants {
                         break;
                     }
                 }
-                assertTrue("UserRoleDTO not found in expectedRoles: " + rtnRole,found);
+                assertTrue(found, "UserRoleDTO not found in expectedRoles: " + rtnRole);
             }
         }
     }


### PR DESCRIPTION
- replaced javax.servlet.* with jakarta.servlet.*
- UserPrincipal, removed Apache CollectionUtils since we only had one use of one method
- SecurityConfig, now uses a Bean to define the API security.
- Created RestTemplateConfig, presently used only in ToBeReviewedCheckerServiceImpl
- ToBeReviewedCheckerServiceImpl, removed restTemplate generator, as that is now done by RestTemplateConfig
- To the tests, added @Import(SecurityConfig.class) so that it would load the security configuration before attempting a test API call, so that the call would be authorized as expected (or not).
- pom.xml, updated versions of various dependencies to their most recent, and hopefully Java-22-compatible versions.