### PR TITLE
TRIB-289: adds AttributesApplyPhraseToUser DTO and in review notification

### DIFF
--- a/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
@@ -94,7 +94,7 @@ public class AttributesAPIController {
     public ResponseEntity<AttributesApplyPhraseToUserDTO> applyPhraseToUser(@RequestBody @Valid AttributesRequest req) {
 
         if (!phraseService.isPhraseValid(req.adverb, req.verb, req.preposition, req.noun)) {
-          AttributesApplyPhraseToUserDTO rtn = phraseService.constructAttributesApplyPhraseToUserDTO(false, false, true, false);
+          AttributesApplyPhraseToUserDTO rtn = phraseService.constructAttributesApplyPhraseToUserDTO(false,true,false);
           sendNotification(rtn, req.userId);
           return ResponseEntity.status(HttpStatus.OK).body(rtn);
         }
@@ -114,7 +114,7 @@ public class AttributesAPIController {
     }
 
     private void sendNotification(AttributesApplyPhraseToUserDTO dto, Long userId) {
-        if (dto.isSuccess && dto.isApproved) {
+        if (dto.isApproved) {
             notificationService.createNotification(
                     NotificationType.ATTRIBUTE_REQUEST_APPROVED,
                     userId,

--- a/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
@@ -7,7 +7,6 @@ import com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPICon
 import com.savvato.tribeapp.controllers.dto.AttributesRequest;
 import com.savvato.tribeapp.dto.AttributeDTO;
 import com.savvato.tribeapp.dto.AttributesApplyPhraseToUserDTO;
-import com.savvato.tribeapp.dto.GenericResponseDTO;
 import com.savvato.tribeapp.dto.ToBeReviewedDTO;
 import com.savvato.tribeapp.entities.NotificationType;
 import com.savvato.tribeapp.services.*;

--- a/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/AttributesAPIController.java
@@ -72,10 +72,10 @@ public class AttributesAPIController {
     @ApplyPhraseToUser
     @PostMapping
     public ResponseEntity<GenericResponseDTO> applyPhraseToUser(@RequestBody @Valid AttributesRequest req) {
-      if (phraseService.isPhraseValid(req.adverb, req.verb, req.preposition, req.noun)) {
+      if (!phraseService.isPhraseInvalid(req.adverb, req.verb, req.preposition, req.noun).isRejected) {
         boolean isPhraseApplied =
             phraseService.applyPhraseToUser(
-                req.userId, req.adverb, req.verb, req.preposition, req.noun);
+                req.userId, req.adverb, req.verb, req.preposition, req.noun).isSuccess;
         if (isPhraseApplied) {
           sendNotification(true, req.userId);
           GenericResponseDTO rtn = GenericResponseService.createDTO("true");

--- a/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/AttributesAPIController/ApplyPhraseToUser.java
+++ b/src/main/java/com/savvato/tribeapp/controllers/annotations/controllers/AttributesAPIController/ApplyPhraseToUser.java
@@ -3,6 +3,8 @@ package com.savvato.tribeapp.controllers.annotations.controllers.AttributesAPICo
 import com.savvato.tribeapp.controllers.annotations.requests.DocumentedRequestBody;
 import com.savvato.tribeapp.controllers.annotations.responses.Success;
 import com.savvato.tribeapp.controllers.dto.AttributesRequest;
+import com.savvato.tribeapp.dto.AttributesApplyPhraseToUserDTO;
+import com.savvato.tribeapp.dto.ToBeReviewedDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import java.lang.annotation.*;
@@ -16,10 +18,5 @@ import java.lang.annotation.*;
     description = "Provided a valid AttributesRequest (see schemas), apply phrase to user.")
 @DocumentedRequestBody(implementation = AttributesRequest.class)
 @Success(
-    description = "Successfully applied phrase",
-    examples = {
-      @ExampleObject(name = "Phrase applied successfully", value = "true"),
-      @ExampleObject(name = "Failed to apply phrase", value = "false"),
-      @ExampleObject(name = "Phrase was invalid", value = "false")
-    })
+    description = "Successfully applied phrase", implementation = AttributesApplyPhraseToUserDTO.class)
 public @interface ApplyPhraseToUser {}

--- a/src/main/java/com/savvato/tribeapp/dto/AttributesApplyPhraseToUserDTO.java
+++ b/src/main/java/com/savvato/tribeapp/dto/AttributesApplyPhraseToUserDTO.java
@@ -8,9 +8,6 @@ import lombok.Builder;
 public class AttributesApplyPhraseToUserDTO {
 
     @Schema(example = "true")
-    public boolean isSuccess;
-
-    @Schema(example = "true")
     public boolean isApproved;
 
     @Schema(example = "true")

--- a/src/main/java/com/savvato/tribeapp/dto/AttributesApplyPhraseToUserDTO.java
+++ b/src/main/java/com/savvato/tribeapp/dto/AttributesApplyPhraseToUserDTO.java
@@ -8,15 +8,15 @@ import lombok.Builder;
 public class AttributesApplyPhraseToUserDTO {
 
     @Schema(example = "true")
-    public boolean success;
+    public boolean isSuccess;
 
     @Schema(example = "true")
-    public boolean approved;
+    public boolean isApproved;
 
     @Schema(example = "true")
-    public boolean rejected;
+    public boolean isRejected;
 
     @Schema(example = "true")
-    public boolean inReview;
+    public boolean isInReview;
 
 }

--- a/src/main/java/com/savvato/tribeapp/dto/AttributesApplyPhraseToUserDTO.java
+++ b/src/main/java/com/savvato/tribeapp/dto/AttributesApplyPhraseToUserDTO.java
@@ -1,0 +1,22 @@
+package com.savvato.tribeapp.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "Result of applying phrase to user")
+public class AttributesApplyPhraseToUserDTO {
+
+    @Schema(example = "true")
+    public boolean success;
+
+    @Schema(example = "true")
+    public boolean approved;
+
+    @Schema(example = "true")
+    public boolean rejected;
+
+    @Schema(example = "true")
+    public boolean inReview;
+
+}

--- a/src/main/java/com/savvato/tribeapp/entities/NotificationType.java
+++ b/src/main/java/com/savvato/tribeapp/entities/NotificationType.java
@@ -7,8 +7,8 @@ import jakarta.persistence.*;
 public class NotificationType {
 
     public static final NotificationType ATTRIBUTE_REQUEST_APPROVED = new NotificationType(1L, "Attribute request approved", null);
-    public static final NotificationType ATTRIBUTE_REQUEST_IN_REVIEW = new NotificationType(1L, "Attribute request in review", null);
-    public static final NotificationType ATTRIBUTE_REQUEST_REJECTED = new NotificationType(1L, "Attribute request rejected", null);
+    public static final NotificationType ATTRIBUTE_REQUEST_REJECTED = new NotificationType(2L, "Attribute request rejected", null);
+    public static final NotificationType ATTRIBUTE_REQUEST_IN_REVIEW = new NotificationType(3L, "Attribute request in review", null);
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/savvato/tribeapp/entities/NotificationType.java
+++ b/src/main/java/com/savvato/tribeapp/entities/NotificationType.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 public class NotificationType {
 
     public static final NotificationType ATTRIBUTE_REQUEST_APPROVED = new NotificationType(1L, "Attribute request approved", null);
+    public static final NotificationType ATTRIBUTE_REQUEST_IN_REVIEW = new NotificationType(1L, "Attribute request in review", null);
     public static final NotificationType ATTRIBUTE_REQUEST_REJECTED = new NotificationType(1L, "Attribute request rejected", null);
 
     @Id

--- a/src/main/java/com/savvato/tribeapp/services/PhraseService.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseService.java
@@ -1,15 +1,16 @@
 package com.savvato.tribeapp.services;
 
 import com.savvato.tribeapp.dto.PhraseDTO;
+import com.savvato.tribeapp.dto.AttributesApplyPhraseToUserDTO;
 
 import java.util.Map;
 import java.util.Optional;
 
 public interface PhraseService {
 
-    boolean isPhraseValid(String adverb, String verb, String preposition, String noun);
+    AttributesApplyPhraseToUserDTO isPhraseValid(String adverb, String verb, String preposition, String noun);
 
-    boolean applyPhraseToUser(Long userId, String adverb, String verb, String preposition, String noun);
+    AttributesApplyPhraseToUserDTO applyPhraseToUser(Long userId, String adverb, String verb, String preposition, String noun);
 
     Optional<Long> findPreviouslyApprovedPhraseId(String adverb, String verb, String preposition, String noun);
 

--- a/src/main/java/com/savvato/tribeapp/services/PhraseService.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseService.java
@@ -16,5 +16,5 @@ public interface PhraseService {
 
     Optional<Map<PhraseDTO, Integer>> getPhraseInformationByUserId(Long userId);
 
-    AttributesApplyPhraseToUserDTO constructAttributesApplyPhraseToUserDTO(boolean success, boolean approved, boolean rejected, boolean inReview);
+    AttributesApplyPhraseToUserDTO constructAttributesApplyPhraseToUserDTO(boolean approved, boolean rejected, boolean inReview);
 }

--- a/src/main/java/com/savvato/tribeapp/services/PhraseService.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseService.java
@@ -15,4 +15,6 @@ public interface PhraseService {
     Optional<Long> findPreviouslyApprovedPhraseId(String adverb, String verb, String preposition, String noun);
 
     Optional<Map<PhraseDTO, Integer>> getPhraseInformationByUserId(Long userId);
+
+    AttributesApplyPhraseToUserDTO constructAttributesApplyPhraseToUserDTO(boolean success, boolean approved, boolean rejected, boolean inReview);
 }

--- a/src/main/java/com/savvato/tribeapp/services/PhraseService.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseService.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface PhraseService {
 
-    AttributesApplyPhraseToUserDTO isPhraseValid(String adverb, String verb, String preposition, String noun);
+    boolean isPhraseValid(String adverb, String verb, String preposition, String noun);
 
     AttributesApplyPhraseToUserDTO applyPhraseToUser(Long userId, String adverb, String verb, String preposition, String noun);
 

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -3,6 +3,7 @@ package com.savvato.tribeapp.services;
 import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.dto.PhraseDTO;
 import com.savvato.tribeapp.dto.projections.PhraseWithUserCountDTO;
+import com.savvato.tribeapp.dto.AttributesApplyPhraseToUserDTO;
 import com.savvato.tribeapp.entities.*;
 import com.savvato.tribeapp.repositories.*;
 import lombok.extern.slf4j.Slf4j;
@@ -51,7 +52,7 @@ public class PhraseServiceImpl implements PhraseService {
 
 
     @Override
-    public boolean isPhraseValid(String adverb, String verb, String preposition, String noun) {
+    public AttributesApplyPhraseToUserDTO isPhraseValid(String adverb, String verb, String preposition, String noun) {
 
         String adverbLowerCase = changeToLowerCase(adverb);
         String verbLowerCase = changeToLowerCase(verb);
@@ -63,10 +64,10 @@ public class PhraseServiceImpl implements PhraseService {
                 isPhrasePreviouslyRejected(adverbLowerCase, verbLowerCase, prepositionLowerCase, nounLowerCase)) {
             log.warn("Phrase is not valid.");
 
-            return false;
+            return constructAttributesApplyPhraseToUserDTO(false,false,true,false);
         }
 
-        return true;
+        return constructAttributesApplyPhraseToUserDTO(false, false, false, false);
     }
 
     public String changeToLowerCase(String word) {
@@ -128,7 +129,7 @@ public class PhraseServiceImpl implements PhraseService {
     }
 
     @Override
-    public boolean applyPhraseToUser(Long userId, String adverb, String verb, String preposition, String noun) {
+    public AttributesApplyPhraseToUserDTO applyPhraseToUser(Long userId, String adverb, String verb, String preposition, String noun) {
 
         String adverbLowerCase = adverb.isBlank() ? Constants.NULL_VALUE_WORD : changeToLowerCase(adverb);
         String verbLowerCase = changeToLowerCase(verb);
@@ -144,7 +145,8 @@ public class PhraseServiceImpl implements PhraseService {
             userPhraseRepository.save(userPhrase);
             log.info("Phrase added to user " + userId);
 
-            return true;
+            return constructAttributesApplyPhraseToUserDTO(true,true,false, false);
+
         } else {
             Optional<ToBeReviewed> toBeReviewedPhrase = toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(adverbLowerCase, verbLowerCase, nounLowerCase, prepositionLowerCase);
 
@@ -166,7 +168,7 @@ public class PhraseServiceImpl implements PhraseService {
                 log.info("ToBeReviewed phrase has been mapped to user " + userId);
             }
 
-            return false;
+            return constructAttributesApplyPhraseToUserDTO(false,false,false,true);
         }
     }
 
@@ -275,6 +277,16 @@ public class PhraseServiceImpl implements PhraseService {
                 .preposition(optPreposition.orElse("").replaceFirst(Constants.NULL_VALUE_WORD, ""))
                 .noun(optNoun.orElse(""))
                 .build();
+    }
+
+    public AttributesApplyPhraseToUserDTO constructAttributesApplyPhraseToUserDTO(boolean success, boolean approved, boolean rejected, boolean inReview){
+        AttributesApplyPhraseToUserDTO rtn = AttributesApplyPhraseToUserDTO.builder()
+                .isSuccess(success)
+                .isApproved(approved)
+                .isRejected(rejected)
+                .isInReview(inReview)
+                .build();
+        return rtn;
     }
 
 }

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -279,6 +279,7 @@ public class PhraseServiceImpl implements PhraseService {
                 .build();
     }
 
+    @Override
     public AttributesApplyPhraseToUserDTO constructAttributesApplyPhraseToUserDTO(boolean success, boolean approved, boolean rejected, boolean inReview){
         AttributesApplyPhraseToUserDTO rtn = AttributesApplyPhraseToUserDTO.builder()
                 .isSuccess(success)

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -145,7 +145,7 @@ public class PhraseServiceImpl implements PhraseService {
             userPhraseRepository.save(userPhrase);
             log.info("Phrase added to user " + userId);
 
-            return constructAttributesApplyPhraseToUserDTO(true,true,false, false);
+            return constructAttributesApplyPhraseToUserDTO(true,false, false);
 
         } else {
             Optional<ToBeReviewed> toBeReviewedPhrase = toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(adverbLowerCase, verbLowerCase, nounLowerCase, prepositionLowerCase);
@@ -168,7 +168,7 @@ public class PhraseServiceImpl implements PhraseService {
                 log.info("ToBeReviewed phrase has been mapped to user " + userId);
             }
 
-            return constructAttributesApplyPhraseToUserDTO(true,false,false,true);
+            return constructAttributesApplyPhraseToUserDTO(false,false,true);
         }
     }
 
@@ -280,9 +280,8 @@ public class PhraseServiceImpl implements PhraseService {
     }
 
     @Override
-    public AttributesApplyPhraseToUserDTO constructAttributesApplyPhraseToUserDTO(boolean success, boolean approved, boolean rejected, boolean inReview){
+    public AttributesApplyPhraseToUserDTO constructAttributesApplyPhraseToUserDTO(boolean approved, boolean rejected, boolean inReview){
         AttributesApplyPhraseToUserDTO rtn = AttributesApplyPhraseToUserDTO.builder()
-                .isSuccess(success)
                 .isApproved(approved)
                 .isRejected(rejected)
                 .isInReview(inReview)

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -168,7 +168,7 @@ public class PhraseServiceImpl implements PhraseService {
                 log.info("ToBeReviewed phrase has been mapped to user " + userId);
             }
 
-            return constructAttributesApplyPhraseToUserDTO(false,false,false,true);
+            return constructAttributesApplyPhraseToUserDTO(true,false,false,true);
         }
     }
 

--- a/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
+++ b/src/main/java/com/savvato/tribeapp/services/PhraseServiceImpl.java
@@ -52,7 +52,7 @@ public class PhraseServiceImpl implements PhraseService {
 
 
     @Override
-    public AttributesApplyPhraseToUserDTO isPhraseValid(String adverb, String verb, String preposition, String noun) {
+    public boolean isPhraseValid(String adverb, String verb, String preposition, String noun) {
 
         String adverbLowerCase = changeToLowerCase(adverb);
         String verbLowerCase = changeToLowerCase(verb);
@@ -64,10 +64,10 @@ public class PhraseServiceImpl implements PhraseService {
                 isPhrasePreviouslyRejected(adverbLowerCase, verbLowerCase, prepositionLowerCase, nounLowerCase)) {
             log.warn("Phrase is not valid.");
 
-            return constructAttributesApplyPhraseToUserDTO(false,false,true,false);
+            return false;
         }
 
-        return constructAttributesApplyPhraseToUserDTO(false, false, false, false);
+        return true;
     }
 
     public String changeToLowerCase(String word) {

--- a/src/main/resources/db/migration/changelog-202309050841.xml
+++ b/src/main/resources/db/migration/changelog-202309050841.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <changeSet author="loretdemolas" id="202309050841">
+    <changeSet author="loretdemolas" id="202309050841" context="test">
         <insert tableName="notifications">
             <column name="id" value="3"/>
             <column name="user_id" value="2"/>

--- a/src/main/resources/db/migration/changelog-202309050841.xml
+++ b/src/main/resources/db/migration/changelog-202309050841.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <changeSet author="loretdemolas" id="202309050841" context="test">
+    <changeSet author="loretdemolas" id="202309050841">
         <insert tableName="notifications">
             <column name="id" value="3"/>
             <column name="user_id" value="2"/>

--- a/src/main/resources/db/migration/changelog-202410031119.xml
+++ b/src/main/resources/db/migration/changelog-202410031119.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="audra" id="202410031119-01">
+        <insert tableName="notification_type">
+            <column name="id" value="3"/>
+            <column name="name" value="Attribute request in review"/>
+            <column name="icon_url" value="hourglass-outline"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/migration/changelog-master.xml
+++ b/src/main/resources/db/migration/changelog-master.xml
@@ -47,12 +47,8 @@
     <include file="changelog-202401111012.xml" relativeToChangelogFile="true"/>
     <include file="changelog-202401090508.xml" relativeToChangelogFile="true"/>
     <include file="changelog-202403270537.xml" relativeToChangelogFile="true"/>
-<<<<<<< HEAD
-    <include file="changelog-202410031119.xml" relativeToChangelogFile="true"/>
-
-=======
     <include file="changelog-202404091617.xml" relativeToChangelogFile="true"/>
     <include file="changelog-202405071617.xml" relativeToChangelogFile="true"/>
->>>>>>> feature/review-attributes-page
+    <include file="changelog-202410031119.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>
 

--- a/src/main/resources/db/migration/changelog-master.xml
+++ b/src/main/resources/db/migration/changelog-master.xml
@@ -47,6 +47,7 @@
     <include file="changelog-202401111012.xml" relativeToChangelogFile="true"/>
     <include file="changelog-202401090508.xml" relativeToChangelogFile="true"/>
     <include file="changelog-202403270537.xml" relativeToChangelogFile="true"/>
+    <include file="changelog-202410031119.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>
 

--- a/src/test/java/com/savvato/tribeapp/integration/controllers/AttributesAPIIT.java
+++ b/src/test/java/com/savvato/tribeapp/integration/controllers/AttributesAPIIT.java
@@ -159,7 +159,6 @@ public class AttributesAPIIT implements UserTestConstants, PhraseTestConstants {
 
         AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
                 .builder()
-                .isSuccess(true)
                 .isApproved(true)
                 .isRejected(false)
                 .isInReview(false)
@@ -180,7 +179,7 @@ public class AttributesAPIIT implements UserTestConstants, PhraseTestConstants {
         ArgumentCaptor<String> notificationTypeNameCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> notificationContentCaptor = ArgumentCaptor.forClass(String.class);
 
-        String expectedMessage = "{\"isSuccess\": true, \"isApproved\": true, \"isRejected\": false, \"isInReview\": false}";
+        String expectedMessage = "{\"isApproved\": true, \"isRejected\": false, \"isInReview\": false}";
 
         this.mockMvc
                 .perform(
@@ -223,7 +222,6 @@ public class AttributesAPIIT implements UserTestConstants, PhraseTestConstants {
 
         AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
                 .builder()
-                .isSuccess(true)
                 .isApproved(false)
                 .isRejected(false)
                 .isInReview(true)
@@ -246,7 +244,7 @@ public class AttributesAPIIT implements UserTestConstants, PhraseTestConstants {
         String notificationContent =
                 "Your attribute will be reviewed.";
 
-        String expectedMessage = "{\"isSuccess\": true, \"isApproved\": false, \"isRejected\": false, \"isInReview\": true}";
+        String expectedMessage = "{\"isApproved\": false, \"isRejected\": false, \"isInReview\": true}";
 
         this.mockMvc
                 .perform(
@@ -289,7 +287,6 @@ public class AttributesAPIIT implements UserTestConstants, PhraseTestConstants {
 
         AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
                 .builder()
-                .isSuccess(false)
                 .isApproved(false)
                 .isRejected(true)
                 .isInReview(false)
@@ -297,7 +294,7 @@ public class AttributesAPIIT implements UserTestConstants, PhraseTestConstants {
 
         when(phraseService.isPhraseValid(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(false);
-        when((phraseService.constructAttributesApplyPhraseToUserDTO(anyBoolean(),anyBoolean(),anyBoolean(),anyBoolean()))).thenReturn(expectedDTO);
+        when((phraseService.constructAttributesApplyPhraseToUserDTO(anyBoolean(),anyBoolean(),anyBoolean()))).thenReturn(expectedDTO);
         when(notificationService.createNotification(
                 any(NotificationType.class), anyLong(), anyString(), anyString()))
                 .thenReturn(null);
@@ -310,7 +307,7 @@ public class AttributesAPIIT implements UserTestConstants, PhraseTestConstants {
         String notificationContent =
                 "Your attribute was rejected. This attribute is unsuitable and cannot be applied to users.";
 
-        String expectedMessage = "{\"isSuccess\": false, \"isApproved\": false, \"isRejected\": true, \"isInReview\": false}";
+        String expectedMessage = "{\"isApproved\": false, \"isRejected\": true, \"isInReview\": false}";
 
         this.mockMvc
                 .perform(

--- a/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
@@ -53,6 +53,9 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
     @Autowired
     PhraseService phraseService;
 
+    @Autowired
+    PhraseServiceImpl phraseServiceImpl; // for testing helper method
+
     @MockBean
     PhraseRepository phraseRepository;
 
@@ -429,6 +432,48 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
         ArgumentCaptor<String> argNoun = ArgumentCaptor.forClass(String.class);
         verify(toBeReviewedRepository, times(1)).findByAdverbAndVerbAndNounAndPreposition(argAdverb.capture(), argVerb.capture(), argNoun.capture(), argPreposition.capture());
         assertEquals(argPreposition.getValue(), testPrepositionConverted);
+    }
+
+    @Test
+    public void testConstructPhraseDTPFromPhraseInformationWhenPhraseHasAllFourWords() {
+        PhraseDTO expectedDTO = PhraseDTO.builder()
+                .id(PhraseTestConstants.PHRASE1_ID)
+                .adverb(PhraseTestConstants.ADVERB1_WORD)
+                .verb(PhraseTestConstants.VERB1_WORD)
+                .preposition(PhraseTestConstants.PREPOSITION1_WORD)
+                .noun(PhraseTestConstants.NOUN1_WORD)
+                .build();
+
+        when(adverbRepository.findAdverbById(anyLong())).thenReturn(Optional.of(ADVERB1_WORD));
+        when(verbRepository.findVerbById(anyLong())).thenReturn(Optional.of(VERB1_WORD));
+        when(prepositionRepository.findPrepositionById(anyLong())).thenReturn(Optional.of(PREPOSITION1_WORD));
+        when(nounRepository.findNounById(anyLong())).thenReturn(Optional.of(NOUN1_WORD));
+
+        PhraseDTO actualDTO = phraseServiceImpl.constructPhraseDTOFromPhraseInformation(PHRASE1_ID, ADVERB1_ID, VERB1_ID, PREPOSITION1_ID, NOUN1_ID);
+
+        AssertionsForClassTypes.assertThat(actualDTO).usingRecursiveComparison().isEqualTo(expectedDTO);
+
+    }
+
+    @Test
+    public void testConstructPhraseDTPFromPhraseInformationWhenPhraseOnlyHasVerbAndNoun() {
+        PhraseDTO expectedDTO = PhraseDTO.builder()
+                .id(PhraseTestConstants.PHRASE1_ID)
+                .adverb("")
+                .verb(PhraseTestConstants.VERB1_WORD)
+                .preposition("")
+                .noun(PhraseTestConstants.NOUN1_WORD)
+                .build();
+
+        when(adverbRepository.findAdverbById(anyLong())).thenReturn(Optional.of(Constants.NULL_VALUE_WORD));
+        when(verbRepository.findVerbById(anyLong())).thenReturn(Optional.of(VERB1_WORD));
+        when(prepositionRepository.findPrepositionById(anyLong())).thenReturn(Optional.of(Constants.NULL_VALUE_WORD));
+        when(nounRepository.findNounById(anyLong())).thenReturn(Optional.of(NOUN1_WORD));
+
+        PhraseDTO actualDTO = phraseServiceImpl.constructPhraseDTOFromPhraseInformation(PHRASE1_ID, Constants.NULL_VALUE_ID, VERB1_ID, Constants.NULL_VALUE_ID, NOUN1_ID);
+
+        AssertionsForClassTypes.assertThat(actualDTO).usingRecursiveComparison().isEqualTo(expectedDTO);
+
     }
 
 }

--- a/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
@@ -243,7 +243,7 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
         AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
                 .builder()
-                .isSuccess(false)
+                .isSuccess(true)
                 .isApproved(false)
                 .isRejected(false)
                 .isInReview(true)
@@ -283,7 +283,7 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
         AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
                 .builder()
-                .isSuccess(false)
+                .isSuccess(true)
                 .isApproved(false)
                 .isRejected(false)
                 .isInReview(true)
@@ -371,7 +371,7 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
         AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
                 .builder()
-                .isSuccess(false)
+                .isSuccess(true)
                 .isApproved(false)
                 .isRejected(false)
                 .isInReview(true)
@@ -413,7 +413,7 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
         AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
                 .builder()
-                .isSuccess(false)
+                .isSuccess(true)
                 .isApproved(false)
                 .isRejected(false)
                 .isInReview(true)

--- a/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
@@ -450,39 +450,4 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
     }
 
-    @Test
-    public void testConstructPhraseDTOFromPhraseInformationWhenPhraseOnlyHasVerbAndNoun() {
-        PhraseDTO expectedDTO = PhraseDTO.builder()
-                .id(PhraseTestConstants.PHRASE1_ID)
-                .adverb("")
-                .verb(PhraseTestConstants.VERB1_WORD)
-                .preposition("")
-                .noun(PhraseTestConstants.NOUN1_WORD)
-                .build();
-
-        when(adverbRepository.findAdverbById(anyLong())).thenReturn(Optional.of(Constants.NULL_VALUE_WORD));
-        when(verbRepository.findVerbById(anyLong())).thenReturn(Optional.of(VERB1_WORD));
-        when(prepositionRepository.findPrepositionById(anyLong())).thenReturn(Optional.of(Constants.NULL_VALUE_WORD));
-        when(nounRepository.findNounById(anyLong())).thenReturn(Optional.of(NOUN1_WORD));
-
-        PhraseDTO actualDTO = phraseServiceImpl.constructPhraseDTOFromPhraseInformation(PHRASE1_ID, Constants.NULL_VALUE_ID, VERB1_ID, Constants.NULL_VALUE_ID, NOUN1_ID);
-
-        AssertionsForClassTypes.assertThat(actualDTO).usingRecursiveComparison().isEqualTo(expectedDTO);
-        
-    }
-
-    @Test
-    public void testConstructAttributesApplyPhraseToUserDTO() {
-        AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO.builder()
-                .isApproved(true)
-                .isRejected(true)
-                .isInReview(true)
-                .build();
-
-        AttributesApplyPhraseToUserDTO actualDTO = phraseService.constructAttributesApplyPhraseToUserDTO( true, true, true);
-
-        AssertionsForClassTypes.assertThat(actualDTO).usingRecursiveComparison().isEqualTo(expectedDTO);
-
-    }
-
 }

--- a/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
@@ -3,6 +3,7 @@ package com.savvato.tribeapp.unit.services;
 import com.savvato.tribeapp.constants.Constants;
 import com.savvato.tribeapp.constants.PhraseTestConstants;
 import com.savvato.tribeapp.constants.UserTestConstants;
+import com.savvato.tribeapp.dto.AttributesApplyPhraseToUserDTO;
 import com.savvato.tribeapp.dto.PhraseDTO;
 import com.savvato.tribeapp.dto.projections.PhraseWithUserCountDTO;
 import com.savvato.tribeapp.entities.*;
@@ -10,6 +11,7 @@ import com.savvato.tribeapp.repositories.*;
 import com.savvato.tribeapp.services.PhraseService;
 import com.savvato.tribeapp.services.PhraseServiceImpl;
 import com.savvato.tribeapp.services.UserPhraseService;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -201,10 +203,18 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
         Mockito.when(userPhraseRepository.save(Mockito.any())).thenReturn(userPhrase);
 
-        boolean rtn = phraseService.applyPhraseToUser(user1.getId(), "testAdverb", "testVerb", "testPreposition", "testNoun");
+        AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
+                .builder()
+                .isSuccess(true)
+                .isApproved(true)
+                .isRejected(false)
+                .isInReview(false)
+                .build();
+
+        AttributesApplyPhraseToUserDTO actualDTO = phraseService.applyPhraseToUser(user1.getId(), "testAdverb", "testVerb", "testPreposition", "testNoun");
 
         verify(userPhraseRepository, times(1)).save(Mockito.any());
-        assertTrue(rtn);
+        AssertionsForClassTypes.assertThat(actualDTO).usingRecursiveComparison().isEqualTo(expectedDTO);
 
     }
 
@@ -233,10 +243,18 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
         Mockito.when(toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(anyString(), anyString(), anyString(), anyString())).thenReturn(Optional.of(toBeReviewed));
 
-        boolean rtn = phraseService.applyPhraseToUser(user1.getId(), testWord, testWord, testWord, testWord);
+        AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
+                .builder()
+                .isSuccess(false)
+                .isApproved(false)
+                .isRejected(false)
+                .isInReview(true)
+                .build();
+
+        AttributesApplyPhraseToUserDTO actualDTO = phraseService.applyPhraseToUser(user1.getId(), testWord, testWord, testWord, testWord);
 
         verify(reviewSubmittingUserRepository, times(1)).save(Mockito.any());
-        assertFalse(rtn);
+        AssertionsForClassTypes.assertThat(actualDTO).usingRecursiveComparison().isEqualTo(expectedDTO);
     }
 
     // Test that reviewSubmittingUserRepository is called once when calling ApplyPhraseToUser and conditions:
@@ -262,12 +280,21 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
         Mockito.when(phraseRepository.findByAdverbIdAndVerbIdAndPrepositionIdAndNounId(any(Long.class), any(Long.class), any(Long.class), any(Long.class))).thenReturn(Optional.empty());
 
-        Mockito.when(toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(anyString(), anyString(), anyString(), anyString())).thenReturn(Optional.of(toBeReviewed));
+        Mockito.when(toBeReviewedRepository.findByAdverbAndVerbAndNounAndPreposition(anyString(), anyString(), anyString(), anyString())).thenReturn(Optional.empty());
+        Mockito.when(toBeReviewedRepository.save(Mockito.any())).thenReturn(toBeReviewed);
 
-        boolean rtn = phraseService.applyPhraseToUser(user1.getId(), testWord, testWord, testWord, testWord);
+        AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
+                .builder()
+                .isSuccess(false)
+                .isApproved(false)
+                .isRejected(false)
+                .isInReview(true)
+                .build();
+
+        AttributesApplyPhraseToUserDTO actualDTO = phraseService.applyPhraseToUser(user1.getId(), testWord, testWord, testWord, testWord);
 
         verify(reviewSubmittingUserRepository, times(1)).save(Mockito.any());
-        assertFalse(rtn);
+        AssertionsForClassTypes.assertThat(actualDTO).usingRecursiveComparison().isEqualTo(expectedDTO);
     }
 
     @Test
@@ -343,8 +370,17 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
         // Should return false if the phrase has not been seen before
         Mockito.when(toBeReviewedRepository.save(any())).thenReturn(tbrSaved);
-        boolean applyPhraseToUser = phraseService.applyPhraseToUser(user1.getId(), testAdverbEmpty, testVerb, testPreposition, testNoun);
-        assertFalse(applyPhraseToUser);
+
+        AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
+                .builder()
+                .isSuccess(false)
+                .isApproved(false)
+                .isRejected(false)
+                .isInReview(true)
+                .build();
+
+        AttributesApplyPhraseToUserDTO actualDTO = phraseService.applyPhraseToUser(user1.getId(), testAdverbEmpty, testVerb, testPreposition, testNoun);
+        AssertionsForClassTypes.assertThat(actualDTO).usingRecursiveComparison().isEqualTo(expectedDTO);
 
         // Empty Adverb should be converted to "nullvalue"
         ArgumentCaptor<String> argAdverb = ArgumentCaptor.forClass(String.class);
@@ -376,8 +412,17 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
         Mockito.when(toBeReviewedRepository.save(any())).thenReturn(tbrSaved);
         when(nounRepository.findByWord(anyString())).thenReturn(Optional.of(new Noun(testNoun)));
         when(verbRepository.findByWord(anyString())).thenReturn(Optional.of(new Verb(testVerb)));
-        boolean applyPhraseToUser = phraseService.applyPhraseToUser(user1.getId(), testAdverb, testVerb, testPrepositionBlank, testNoun);
-        assertFalse(applyPhraseToUser);
+
+        AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
+                .builder()
+                .isSuccess(false)
+                .isApproved(false)
+                .isRejected(false)
+                .isInReview(true)
+                .build();
+
+        AttributesApplyPhraseToUserDTO actualDTO = phraseService.applyPhraseToUser(user1.getId(), testAdverb, testVerb, testPrepositionBlank, testNoun);
+        AssertionsForClassTypes.assertThat(actualDTO).usingRecursiveComparison().isEqualTo(expectedDTO);
 
         // Empty Preposition should be converted to "nullvalue"
         ArgumentCaptor<String> argAdverb = ArgumentCaptor.forClass(String.class);

--- a/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
@@ -435,7 +435,7 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
     }
 
     @Test
-    public void testConstructPhraseDTPFromPhraseInformationWhenPhraseHasAllFourWords() {
+    public void testConstructPhraseDTOFromPhraseInformationWhenPhraseHasAllFourWords() {
         PhraseDTO expectedDTO = PhraseDTO.builder()
                 .id(PhraseTestConstants.PHRASE1_ID)
                 .adverb(PhraseTestConstants.ADVERB1_WORD)
@@ -456,7 +456,7 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
     }
 
     @Test
-    public void testConstructPhraseDTPFromPhraseInformationWhenPhraseOnlyHasVerbAndNoun() {
+    public void testConstructPhraseDTOFromPhraseInformationWhenPhraseOnlyHasVerbAndNoun() {
         PhraseDTO expectedDTO = PhraseDTO.builder()
                 .id(PhraseTestConstants.PHRASE1_ID)
                 .adverb("")
@@ -473,7 +473,7 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
         PhraseDTO actualDTO = phraseServiceImpl.constructPhraseDTOFromPhraseInformation(PHRASE1_ID, Constants.NULL_VALUE_ID, VERB1_ID, Constants.NULL_VALUE_ID, NOUN1_ID);
 
         AssertionsForClassTypes.assertThat(actualDTO).usingRecursiveComparison().isEqualTo(expectedDTO);
-
+        
     }
 
     @Test
@@ -488,7 +488,7 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
         AttributesApplyPhraseToUserDTO actualDTO = phraseService.constructAttributesApplyPhraseToUserDTO(true, true, true, true);
 
         AssertionsForClassTypes.assertThat(actualDTO).usingRecursiveComparison().isEqualTo(expectedDTO);
-        
+
     }
 
 }

--- a/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
@@ -149,7 +149,6 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
         });
     }
 
-    // test that false is returned when method is called with a rejected word
     @Test
     public void testIsWordRejectedHappyPath() {
 
@@ -162,8 +161,7 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
         assertFalse(phraseService.isPhraseValid(rejectedWord, rejectedWord, rejectedWord, rejectedWord));
     }
-
-    // test that false is returned when method is called with a rejected phrase
+    
     @Test
     public void testIsPhrasePreviouslyRejectedHappyPath() {
 

--- a/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
@@ -206,7 +206,6 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
         AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
                 .builder()
-                .isSuccess(true)
                 .isApproved(true)
                 .isRejected(false)
                 .isInReview(false)
@@ -246,7 +245,6 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
         AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
                 .builder()
-                .isSuccess(true)
                 .isApproved(false)
                 .isRejected(false)
                 .isInReview(true)
@@ -286,7 +284,6 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
         AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
                 .builder()
-                .isSuccess(true)
                 .isApproved(false)
                 .isRejected(false)
                 .isInReview(true)
@@ -374,7 +371,6 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
         AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
                 .builder()
-                .isSuccess(true)
                 .isApproved(false)
                 .isRejected(false)
                 .isInReview(true)
@@ -416,7 +412,6 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
         AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO
                 .builder()
-                .isSuccess(true)
                 .isApproved(false)
                 .isRejected(false)
                 .isInReview(true)
@@ -479,13 +474,12 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
     @Test
     public void testConstructAttributesApplyPhraseToUserDTO() {
         AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO.builder()
-                .isSuccess(true)
                 .isApproved(true)
                 .isRejected(true)
                 .isInReview(true)
                 .build();
 
-        AttributesApplyPhraseToUserDTO actualDTO = phraseService.constructAttributesApplyPhraseToUserDTO(true, true, true, true);
+        AttributesApplyPhraseToUserDTO actualDTO = phraseService.constructAttributesApplyPhraseToUserDTO( true, true, true);
 
         AssertionsForClassTypes.assertThat(actualDTO).usingRecursiveComparison().isEqualTo(expectedDTO);
 

--- a/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
+++ b/src/test/java/com/savvato/tribeapp/unit/services/PhraseServiceImplTest.java
@@ -476,4 +476,19 @@ public class PhraseServiceImplTest implements UserTestConstants, PhraseTestConst
 
     }
 
+    @Test
+    public void testConstructAttributesApplyPhraseToUserDTO() {
+        AttributesApplyPhraseToUserDTO expectedDTO = AttributesApplyPhraseToUserDTO.builder()
+                .isSuccess(true)
+                .isApproved(true)
+                .isRejected(true)
+                .isInReview(true)
+                .build();
+
+        AttributesApplyPhraseToUserDTO actualDTO = phraseService.constructAttributesApplyPhraseToUserDTO(true, true, true, true);
+
+        AssertionsForClassTypes.assertThat(actualDTO).usingRecursiveComparison().isEqualTo(expectedDTO);
+        
+    }
+
 }


### PR DESCRIPTION
- Adds AttiributesApplyPhraseToUserDTO
- Refactors AttributeAPI applyPhraseToUser endpoint to use new DTO
- Refactors PhraseService applyPhraseToUser to use new DTO
- Refactors AttributeAPI sendNotification with a third notification type for in review
- Adds new notification type for in review
- Updates database with new notification type

Testing:
- updated tests with new DTO
- added PhraseService tests for DTO builders (may not be necessary)
- expected results returned in Postman

NOTE: changes data returned to the frontend!
Old implementation:
returned GenericResponseDTO.BooleanMessage
- false: phrase was either rejected or put in toBeReviewed
- true: phrase was applied to user

New implementation:
returns AttributesApplyPhraseToUserDTO with one field set to true and the rest to false.
- isApproved = true: phrase was applied to user
- isRejected = true: phrase was rejected
- isInReivew = true: phrase was placed in toBeReviewed